### PR TITLE
Add a namespace

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class Indicator : Wingpanel.Indicator {
+public class Notifications.Indicator : Wingpanel.Indicator {
     private const string[] EXCEPTIONS = { "NetworkManager", "gnome-settings-daemon", "gnome-power-panel" };
     private const string CHILD_SCHEMA_ID = "org.pantheon.desktop.gala.notifications.application";
     private const string CHILD_PATH = "/org/pantheon/desktop/gala/notifications/applications/%s/";
@@ -224,6 +224,6 @@ public Wingpanel.Indicator? get_indicator (Module module, Wingpanel.IndicatorMan
         return null;
     }
 
-    var indicator = new Indicator ();
+    var indicator = new Notifications.Indicator ();
     return indicator;
 }

--- a/src/Services/Interfaces.vala
+++ b/src/Services/Interfaces.vala
@@ -16,7 +16,7 @@
  */
 
 [DBus (name = "org.freedesktop.Notifications")]
-public interface INotifications : Object {
+public interface Notifications.INotifications : Object {
     public signal void notification_closed (uint32 id, uint32 reason);
     public signal void action_invoked (string action, uint32 id);
     public abstract uint32 notify (string app_name,
@@ -30,7 +30,7 @@ public interface INotifications : Object {
 }
 
 [DBus (name = "org.freedesktop.DBus")]
-public interface IDBus : Object {
+public interface Notifications.IDBus : Object {
     [DBus (name = "NameHasOwner")]
     public abstract bool name_has_owner (string name) throws Error;
 

--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class Notification : Object {
+public class Notifications.Notification : Object {
     public const string DESKTOP_ID_EXT = ".desktop";
 
     public bool data_session;

--- a/src/Services/NotificationsMonitor.vala
+++ b/src/Services/NotificationsMonitor.vala
@@ -20,7 +20,7 @@
  * http://bazaar.launchpad.net/~jconti/recent-notifications/gnome3/view/head:/src/recent-notifications.vala
  */
 
-public class NotificationMonitor : Object {
+public class Notifications.NotificationMonitor : Object {
     private const string NOTIFY_IFACE = "org.freedesktop.Notifications";
     private const string NOTIFY_PATH = "/org/freedesktop/Notifications";
     private const string METHOD_CALL_MATCH_STRING = "eavesdrop='true',type='method_call',interface='org.freedesktop.Notifications'";

--- a/src/Services/NotifySettings.vala
+++ b/src/Services/NotifySettings.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class NotifySettings : Granite.Services.Settings {
+public class Notifications.NotifySettings : Granite.Services.Settings {
     public const string DO_NOT_DISTURB_KEY = "do-not-disturb";
     public static NotifySettings? instance = null;
 

--- a/src/Services/Session.vala
+++ b/src/Services/Session.vala
@@ -21,7 +21,7 @@
  * and restore them in the next session.
  *
  */
-public class Session : GLib.Object {
+public class Notifications.Session : GLib.Object {
     private const string SESSION_FILE_NAME = ".notifications.session";
     private static Session? instance = null;
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class Utils : Object {
+public class Notifications.Utils : Object {
     private static Gee.HashMap<string, AppInfo> app_info_cache;
 
     public static void init () {

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class AppEntry : Gtk.ListBoxRow {
+public class Notifications.AppEntry : Gtk.ListBoxRow {
     public signal void clear ();
 
     public AppInfo app_info;

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class NotificationEntry : Gtk.ListBoxRow {
+public class Notifications.NotificationEntry : Gtk.ListBoxRow {
     public signal void clear ();
 
     public Notification notification;

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class NotificationsList : Gtk.ListBox {
+public class Notifications.NotificationsList : Gtk.ListBox {
     public signal void switch_stack (bool show_list);
     public signal void close_popover ();
 

--- a/src/Widgets/SeparatorEntry.vala
+++ b/src/Widgets/SeparatorEntry.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- public class SeparatorEntry : Gtk.ListBoxRow {
+ public class Notifications.SeparatorEntry : Gtk.ListBoxRow {
  	public SeparatorEntry () {
  		activatable = selectable = false;
  		add (new Wingpanel.Widgets.Separator ());


### PR DESCRIPTION
Fixes the issue when updating the indicator the wingpanel crashes because of the already existing `Indicator`. Now every class is in the `Notifications` namespace. To test: navigate to `/usr/lib/x86_64-linux-gnu/wingpanel/` and duplicate `libnotifications-indicator.so` in this directory. With trunk, wingpanel will crash, with this branch, it shouldn't.