### PR TITLE
Ellipsizes notification summary when it is too long

### DIFF
--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -62,6 +62,8 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         grid.margin_end = 6;
 
         var title_label = new Gtk.Label ("<b>" + fix_markup (entry_summary) + "</b>");
+        title_label.wrap_mode = Pango.WrapMode.WORD_CHAR;
+        title_label.max_width_chars = 32;
         ((Gtk.Misc) title_label).xalign = 0.0f;
         title_label.hexpand = true;
         title_label.use_markup = true;


### PR DESCRIPTION
Wraps notification summary/title when it is too long to fit in the popover instead of making it larger.

Before:
![captura de pantalla de 2017-05-30 11-50-09](https://cloud.githubusercontent.com/assets/165044/26660059/ccc40580-464b-11e7-8407-c721f8185910.png)

After:
![captura de pantalla de 2017-06-01 10-38-42](https://cloud.githubusercontent.com/assets/165044/26682414/ce86178a-46b6-11e7-9043-472ece5a88e1.png)

Closes #19.