### PR TITLE
Fix application not opening when clicking on the notification

### DIFF
--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -216,7 +216,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
     private bool focus_notification_app (Wnck.Window? app_window, AppInfo? app_info) {
         if (app_window != null) {
-            app_window.unminimize (Gtk.get_current_event_time ());
+            app_window.activate (Gtk.get_current_event_time ());
             return true;
         } else if (app_info != null) {
             try {


### PR DESCRIPTION
Fixes #1.

This is a fix that was proposed by @giulianofiorotto, so I decided to submit a PR here on GitHub so it can get merged. Note that the bounty should go to Giuliano, not to me. I'm just applying the same fix (without one line) and posting it here.

Original branch on LP: https://code.launchpad.net/~mr-fiorotto/wingpanel-indicator-notifications/trying-to-fix-/+merge/315178