### PR TITLE
CSS icon change

### DIFF
--- a/cmake/GResource.cmake
+++ b/cmake/GResource.cmake
@@ -1,0 +1,67 @@
+#
+#    Copyright (C) 2013 Venom authors and contributors
+#
+#    This file is part of Venom.
+#
+#    Venom is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Venom is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Venom.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+FIND_PROGRAM(GLIB_COMPILE_RESOURCES_EXECUTABLE NAMES glib-compile-resources)
+MARK_AS_ADVANCED(GLIB_COMPILE_RESOURCES_EXECUTABLE)
+
+INCLUDE(CMakeParseArguments)
+
+FUNCTION(GLIB_COMPILE_RESOURCES output)
+  CMAKE_PARSE_ARGUMENTS(ARGS "" "SOURCE" "" ${ARGN})
+  SET(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  SET(out_files "")
+
+  FOREACH(src ${ARGS_SOURCE} ${ARGS_UNPARSED_ARGUMENTS})
+    SET(in_file "${CMAKE_CURRENT_SOURCE_DIR}/${src}")
+    GET_FILENAME_COMPONENT(WORKING_DIR ${in_file} PATH)
+    STRING(REPLACE ".xml" ".c" src ${src})
+    SET(out_file "${DIRECTORY}/${src}")
+    GET_FILENAME_COMPONENT(OUPUT_DIR ${out_file} PATH)
+    FILE(MAKE_DIRECTORY ${OUPUT_DIR})
+    LIST(APPEND out_files "${DIRECTORY}/${src}")
+
+    #FIXME implicit depends currently not working
+    EXECUTE_PROCESS(
+      COMMAND
+        ${GLIB_COMPILE_RESOURCES_EXECUTABLE}
+          "--generate-dependencies"
+          ${in_file}
+      WORKING_DIRECTORY ${WORKING_DIR}
+      OUTPUT_VARIABLE in_file_dep
+    )
+    STRING(REGEX REPLACE "(\r?\n)" ";" in_file_dep "${in_file_dep}")
+    SET(in_file_dep_path "")
+    FOREACH(dep ${in_file_dep})
+      LIST(APPEND in_file_dep_path "${WORKING_DIR}/${dep}")
+    ENDFOREACH(dep ${in_file_dep})
+    ADD_CUSTOM_COMMAND(
+      OUTPUT ${out_file}
+      WORKING_DIRECTORY ${WORKING_DIR}
+      COMMAND
+        ${GLIB_COMPILE_RESOURCES_EXECUTABLE}
+      ARGS
+        "--generate-source"
+        "--target=${out_file}"
+        ${in_file}
+      DEPENDS
+        ${in_file};${in_file_dep_path}
+    )
+  ENDFOREACH(src ${ARGS_SOURCES} ${ARGS_UNPARSED_ARGUMENTS})
+  SET(${output} ${out_files} PARENT_SCOPE)
+ENDFUNCTION(GLIB_COMPILE_RESOURCES)

--- a/data/indicator.css
+++ b/data/indicator.css
@@ -1,0 +1,64 @@
+/*
+* Copyright (c) 2017 elementary LLC. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA.
+*/
+
+.notification-icon {
+    animation: none;
+    min-width: 24px;
+    opacity: 1;
+    transition: none;
+    -gtk-icon-source: -gtk-icontheme("notification-symbolic");
+}
+
+.notification-icon.new {
+    animation: new 500ms cubic-bezier(0.4, 0.0, 0.2, 1);
+    -gtk-icon-source: -gtk-icontheme("notification-new-symbolic");
+}
+
+.notification-icon.disabled {
+    animation: disabled 160ms cubic-bezier(0.4, 0.0, 0.2, 1);
+    -gtk-icon-source: -gtk-icontheme("notification-disabled-symbolic");
+}
+
+@keyframes disabled {
+    0% { -gtk-icon-source: -gtk-icontheme("notification-symbolic"); }
+    10% { -gtk-icon-source: -gtk-icontheme("notification-disabled-10-symbolic"); opacity: 0.94; }
+    20% { -gtk-icon-source: -gtk-icontheme("notification-disabled-20-symbolic"); opacity: 0.78; }
+    30% { -gtk-icon-source: -gtk-icontheme("notification-disabled-30-symbolic"); opacity: 0.82; }
+    40% { -gtk-icon-source: -gtk-icontheme("notification-disabled-40-symbolic"); opacity: 0.76; }
+    50% { -gtk-icon-source: -gtk-icontheme("notification-disabled-50-symbolic"); opacity: 0.70; }
+    60% { -gtk-icon-source: -gtk-icontheme("notification-disabled-60-symbolic"); opacity: 0.64; }
+    70% { -gtk-icon-source: -gtk-icontheme("notification-disabled-70-symbolic"); opacity: 0.58; }
+    80% { -gtk-icon-source: -gtk-icontheme("notification-disabled-80-symbolic"); opacity: 0.52; }
+    90% { -gtk-icon-source: -gtk-icontheme("notification-disabled-90-symbolic"); opacity: 0.46; }
+    100% { -gtk-icon-source: -gtk-icontheme("notification-disabled-symbolic"); }
+}
+
+@keyframes new {
+    0% { -gtk-icon-source: -gtk-icontheme("notification-symbolic"); }
+    10% { -gtk-icon-source: -gtk-icontheme("notification-new-10-symbolic"); }
+    20% { -gtk-icon-source: -gtk-icontheme("notification-new-20-symbolic"); }
+    30% { -gtk-icon-source: -gtk-icontheme("notification-new-30-symbolic"); }
+    40% { -gtk-icon-source: -gtk-icontheme("notification-new-40-symbolic"); }
+    50% { -gtk-icon-source: -gtk-icontheme("notification-new-50-symbolic"); }
+    60% { -gtk-icon-source: -gtk-icontheme("notification-new-60-symbolic"); }
+    70% { -gtk-icon-source: -gtk-icontheme("notification-new-70-symbolic"); }
+    80% { -gtk-icon-source: -gtk-icontheme("notification-new-80-symbolic"); }
+    90% { -gtk-icon-source: -gtk-icontheme("notification-new-90-symbolic"); }
+    100% { -gtk-icon-source: -gtk-icontheme("notification-new-symbolic"); }
+}

--- a/data/indicator.css
+++ b/data/indicator.css
@@ -26,16 +26,16 @@
 }
 
 .notification-icon.new {
-    animation: new 500ms cubic-bezier(0.4, 0.0, 0.2, 1);
+    animation: notification-new 500ms cubic-bezier(0.4, 0.0, 0.2, 1);
     -gtk-icon-source: -gtk-icontheme("notification-new-symbolic");
 }
 
 .notification-icon.disabled {
-    animation: disabled 160ms cubic-bezier(0.4, 0.0, 0.2, 1);
+    animation: notification-disabled 160ms cubic-bezier(0.4, 0.0, 0.2, 1);
     -gtk-icon-source: -gtk-icontheme("notification-disabled-symbolic");
 }
 
-@keyframes disabled {
+@keyframes notification-disabled {
     0% { -gtk-icon-source: -gtk-icontheme("notification-symbolic"); }
     10% { -gtk-icon-source: -gtk-icontheme("notification-disabled-10-symbolic"); opacity: 0.94; }
     20% { -gtk-icon-source: -gtk-icontheme("notification-disabled-20-symbolic"); opacity: 0.78; }
@@ -49,7 +49,7 @@
     100% { -gtk-icon-source: -gtk-icontheme("notification-disabled-symbolic"); }
 }
 
-@keyframes new {
+@keyframes notification-new {
     0% { -gtk-icon-source: -gtk-icontheme("notification-symbolic"); }
     10% { -gtk-icon-source: -gtk-icontheme("notification-new-10-symbolic"); }
     20% { -gtk-icon-source: -gtk-icontheme("notification-new-20-symbolic"); }

--- a/data/io.elementary.wingpanel.notifications.gresource.xml
+++ b/data/io.elementary.wingpanel.notifications.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/io/elementary/wingpanel/notifications">
+    <file alias="indicator.css" compressed="true">indicator.css</file>
+  </gresource>
+</gresources>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,10 @@ PACKAGES
   libwnck-3.0
 )
 
-add_library (${CMAKE_PROJECT_NAME} MODULE ${VALA_C})
+include (GResource)
+glib_compile_resources (GLIB_RESOURCES_CSS SOURCE ../data/io.elementary.wingpanel.notifications.gresource.xml)
+
+add_library (${CMAKE_PROJECT_NAME} MODULE ${VALA_C} ${GLIB_RESOURCES_CSS})
 target_link_libraries (${CMAKE_PROJECT_NAME} ${DEPS_LIBRARIES})
 
 # Installation

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -26,7 +26,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     private const string LIST_ID = "list";
     private const string NO_NOTIFICATIONS_ID = "no-notifications";
 
-    private Wingpanel.Widgets.OverlayIcon? dynamic_icon = null;
+    private Gtk.Image? dynamic_icon = null;
     private Gtk.Box? main_box = null;
     private Wingpanel.Widgets.Button clear_all_btn;
     private Gtk.Stack stack;
@@ -48,7 +48,9 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     public override Gtk.Widget get_display_widget () {
         if (dynamic_icon == null)
-            dynamic_icon = new Wingpanel.Widgets.OverlayIcon (get_display_icon_name ());
+            dynamic_icon = new Gtk.Image ();
+            dynamic_icon.get_style_context ().add_class ("notification-icon");
+            set_display_icon_name ();
 
         dynamic_icon.button_press_event.connect ((e) => {
             if (e.button == Gdk.BUTTON_MIDDLE) {
@@ -109,7 +111,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
             NotifySettings.get_instance ().changed[NotifySettings.DO_NOT_DISTURB_KEY].connect (() => {
                 not_disturb_switch.get_switch ().active = NotifySettings.get_instance ().do_not_disturb;
-                dynamic_icon.set_main_icon_name (get_display_icon_name ());
+                set_display_icon_name ();
             });
 
             main_box.add (not_disturb_switch);
@@ -160,7 +162,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             nlist.add_entry (entry);
         }
 
-        dynamic_icon.set_main_icon_name (get_display_icon_name ());        
+        set_display_icon_name ();        
     }
 
     private void on_switch_stack (bool show_list) {
@@ -171,7 +173,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             stack.set_visible_child_name (NO_NOTIFICATIONS_ID);
         }
 
-        dynamic_icon.set_main_icon_name (get_display_icon_name ());        
+        set_display_icon_name ();
     }
 
     private void on_notification_closed (uint32 id) {
@@ -192,14 +194,15 @@ public class Notifications.Indicator : Wingpanel.Indicator {
         });
     }
 
-    private string get_display_icon_name () {
+    private void set_display_icon_name () {
         if (NotifySettings.get_instance ().do_not_disturb) {
-            return "notification-disabled-symbolic";
+            dynamic_icon.get_style_context ().add_class ("disabled");
         } else if (nlist != null && nlist.get_entries_length () > 0) {
-            return "notification-new-symbolic";
+            dynamic_icon.get_style_context ().add_class ("new");
+        } else {
+            dynamic_icon.get_style_context ().remove_class ("disabled");
+            dynamic_icon.get_style_context ().remove_class ("new");
         }
-        
-        return "notification-symbolic";
     }
 
     private void show_settings () {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -51,15 +51,22 @@ public class Notifications.Indicator : Wingpanel.Indicator {
         }
 
         .notification-icon.disabled {
-            animation: disabled 130ms ease-in-out;
-            -gtk-icon-transform: none;
+            animation: disabled 160ms cubic-bezier(0.4, 0.0, 0.2, 1);
             -gtk-icon-source: -gtk-icontheme("notification-disabled-symbolic");
         }
 
         @keyframes disabled {
-            0% { -gtk-icon-source: -gtk-icontheme("notification-disabled-0-symbolic"); }
-            50% { -gtk-icon-source: -gtk-icontheme("notification-disabled-50-symbolic"); }
-            100% { -gtk-icon-source: -gtk-icontheme("notification-disabled-100-symbolic"); }
+            0% { -gtk-icon-source: -gtk-icontheme("notification-symbolic"); }
+            10% { -gtk-icon-source: -gtk-icontheme("notification-disabled-10-symbolic"); opacity: 0.94; }
+            20% { -gtk-icon-source: -gtk-icontheme("notification-disabled-20-symbolic"); opacity: 0.78; }
+            30% { -gtk-icon-source: -gtk-icontheme("notification-disabled-30-symbolic"); opacity: 0.82; }
+            40% { -gtk-icon-source: -gtk-icontheme("notification-disabled-40-symbolic"); opacity: 0.76; }
+            50% { -gtk-icon-source: -gtk-icontheme("notification-disabled-50-symbolic"); opacity: 0.70; }
+            60% { -gtk-icon-source: -gtk-icontheme("notification-disabled-60-symbolic"); opacity: 0.64; }
+            70% { -gtk-icon-source: -gtk-icontheme("notification-disabled-70-symbolic"); opacity: 0.58; }
+            80% { -gtk-icon-source: -gtk-icontheme("notification-disabled-80-symbolic"); opacity: 0.52; }
+            90% { -gtk-icon-source: -gtk-icontheme("notification-disabled-90-symbolic"); opacity: 0.46; }
+            100% { -gtk-icon-source: -gtk-icontheme("notification-disabled-symbolic"); }
         }
     """;
 
@@ -234,13 +241,15 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     }
 
     private void set_display_icon_name () {
+        var dynamic_icon_style_context = dynamic_icon.get_style_context ();
         if (NotifySettings.get_instance ().do_not_disturb) {
-            dynamic_icon.get_style_context ().add_class ("disabled");
+            dynamic_icon_style_context.add_class ("disabled");
         } else if (nlist != null && nlist.get_entries_length () > 0) {
-            dynamic_icon.get_style_context ().add_class ("new");
+            dynamic_icon_style_context.remove_class ("disabled");
+            dynamic_icon_style_context.add_class ("new");
         } else {
-            dynamic_icon.get_style_context ().remove_class ("disabled");
-            dynamic_icon.get_style_context ().remove_class ("new");
+            dynamic_icon_style_context.remove_class ("disabled");
+            dynamic_icon_style_context.remove_class ("new");
         }
     }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -39,7 +39,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
         .notification-icon {
             animation: none;
             min-width: 24px;
-	        opacity: 1;
+            opacity: 1;
             transition: none;
             -gtk-icon-source: -gtk-icontheme("notification-symbolic");
         }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -54,7 +54,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
             var provider = new Gtk.CssProvider ();
             provider.load_from_resource ("io/elementary/wingpanel/notifications/indicator.css");
-            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            dynamic_icon.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
 
         set_display_icon_name ();

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -35,6 +35,22 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     private Gee.HashMap<string, Settings> app_settings_cache;
 
+    private const string ICON_CSS = """
+        .notification-icon {
+            background-image: -gtk-icontheme("notification-symbolic");
+            background-position: center center;
+            background-repeat: no-repeat;
+        }
+
+        .notification-icon.new {
+            background-image: -gtk-icontheme("notification-new-symbolic");
+        }
+
+        .notification-icon.disabled {
+            background-image: -gtk-icontheme("notification-disabled-symbolic");
+        }
+    """;
+
     public Indicator () {
         Object (code_name: Wingpanel.Indicator.MESSAGES,
                 display_name: _("Notifications indicator"),
@@ -47,10 +63,20 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     }
 
     public override Gtk.Widget get_display_widget () {
-        if (dynamic_icon == null)
+        if (dynamic_icon == null) {
             dynamic_icon = new Gtk.Image ();
             dynamic_icon.get_style_context ().add_class ("notification-icon");
-            set_display_icon_name ();
+
+            var provider = new Gtk.CssProvider ();
+            try {
+                provider.load_from_data (ICON_CSS, ICON_CSS.length);
+                Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            } catch (Error e) {
+                critical (e.message);
+            }
+        }
+
+        set_display_icon_name ();
 
         dynamic_icon.button_press_event.connect ((e) => {
             if (e.button == Gdk.BUTTON_MIDDLE) {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -38,7 +38,6 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     private const string ICON_CSS = """
         .notification-icon {
             animation: none;
-            min-height: 24px;
             min-width: 24px;
 	        opacity: 1;
             transition: none;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -45,7 +45,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
         }
 
         .notification-icon.new {
-            animation: none;
+            animation: new 500ms cubic-bezier(0.4, 0.0, 0.2, 1);
             -gtk-icon-source: -gtk-icontheme("notification-new-symbolic");
         }
 
@@ -66,6 +66,20 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             80% { -gtk-icon-source: -gtk-icontheme("notification-disabled-80-symbolic"); opacity: 0.52; }
             90% { -gtk-icon-source: -gtk-icontheme("notification-disabled-90-symbolic"); opacity: 0.46; }
             100% { -gtk-icon-source: -gtk-icontheme("notification-disabled-symbolic"); }
+        }
+
+        @keyframes new {
+            0% { -gtk-icon-source: -gtk-icontheme("notification-symbolic"); }
+            10% { -gtk-icon-source: -gtk-icontheme("notification-new-10-symbolic"); }
+            20% { -gtk-icon-source: -gtk-icontheme("notification-new-20-symbolic"); }
+            30% { -gtk-icon-source: -gtk-icontheme("notification-new-30-symbolic"); }
+            40% { -gtk-icon-source: -gtk-icontheme("notification-new-40-symbolic"); }
+            50% { -gtk-icon-source: -gtk-icontheme("notification-new-50-symbolic"); }
+            60% { -gtk-icon-source: -gtk-icontheme("notification-new-60-symbolic"); }
+            70% { -gtk-icon-source: -gtk-icontheme("notification-new-70-symbolic"); }
+            80% { -gtk-icon-source: -gtk-icontheme("notification-new-80-symbolic"); }
+            90% { -gtk-icon-source: -gtk-icontheme("notification-new-90-symbolic"); }
+            100% { -gtk-icon-source: -gtk-icontheme("notification-new-symbolic"); }
         }
     """;
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -40,6 +40,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             background-image: -gtk-icontheme("notification-symbolic");
             background-position: center center;
             background-repeat: no-repeat;
+            transition: none;
         }
 
         .notification-icon.new {
@@ -47,7 +48,14 @@ public class Notifications.Indicator : Wingpanel.Indicator {
         }
 
         .notification-icon.disabled {
+            animation: disabled 150ms ease-in-out;
             background-image: -gtk-icontheme("notification-disabled-symbolic");
+        }
+
+        @keyframes disabled {
+            0% { background-image: -gtk-icontheme("notification-disabled-0-symbolic"); }
+            50% { background-image: -gtk-icontheme("notification-disabled-50-symbolic"); }
+            100% { background-image: -gtk-icontheme("notification-disabled-100-symbolic"); }
         }
     """;
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -26,7 +26,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     private const string LIST_ID = "list";
     private const string NO_NOTIFICATIONS_ID = "no-notifications";
 
-    private Gtk.Image? dynamic_icon = null;
+    private Gtk.Spinner? dynamic_icon = null;
     private Gtk.Box? main_box = null;
     private Wingpanel.Widgets.Button clear_all_btn;
     private Gtk.Stack stack;
@@ -37,25 +37,29 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     private const string ICON_CSS = """
         .notification-icon {
-            background-image: -gtk-icontheme("notification-symbolic");
-            background-position: center center;
-            background-repeat: no-repeat;
+            animation: none;
+            min-height: 24px;
+            min-width: 24px;
+	        opacity: 1;
             transition: none;
+            -gtk-icon-source: -gtk-icontheme("notification-symbolic");
         }
 
         .notification-icon.new {
-            background-image: -gtk-icontheme("notification-new-symbolic");
+            animation: none;
+            -gtk-icon-source: -gtk-icontheme("notification-new-symbolic");
         }
 
         .notification-icon.disabled {
-            animation: disabled 150ms ease-in-out;
-            background-image: -gtk-icontheme("notification-disabled-symbolic");
+            animation: disabled 130ms ease-in-out;
+            -gtk-icon-transform: none;
+            -gtk-icon-source: -gtk-icontheme("notification-disabled-symbolic");
         }
 
         @keyframes disabled {
-            0% { background-image: -gtk-icontheme("notification-disabled-0-symbolic"); }
-            50% { background-image: -gtk-icontheme("notification-disabled-50-symbolic"); }
-            100% { background-image: -gtk-icontheme("notification-disabled-100-symbolic"); }
+            0% { -gtk-icon-source: -gtk-icontheme("notification-disabled-0-symbolic"); }
+            50% { -gtk-icon-source: -gtk-icontheme("notification-disabled-50-symbolic"); }
+            100% { -gtk-icon-source: -gtk-icontheme("notification-disabled-100-symbolic"); }
         }
     """;
 
@@ -72,7 +76,8 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     public override Gtk.Widget get_display_widget () {
         if (dynamic_icon == null) {
-            dynamic_icon = new Gtk.Image ();
+            dynamic_icon = new Gtk.Spinner ();
+            dynamic_icon.active = true;
             dynamic_icon.get_style_context ().add_class ("notification-icon");
 
             var provider = new Gtk.CssProvider ();

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -35,54 +35,6 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     private Gee.HashMap<string, Settings> app_settings_cache;
 
-    private const string ICON_CSS = """
-        .notification-icon {
-            animation: none;
-            min-width: 24px;
-            opacity: 1;
-            transition: none;
-            -gtk-icon-source: -gtk-icontheme("notification-symbolic");
-        }
-
-        .notification-icon.new {
-            animation: new 500ms cubic-bezier(0.4, 0.0, 0.2, 1);
-            -gtk-icon-source: -gtk-icontheme("notification-new-symbolic");
-        }
-
-        .notification-icon.disabled {
-            animation: disabled 160ms cubic-bezier(0.4, 0.0, 0.2, 1);
-            -gtk-icon-source: -gtk-icontheme("notification-disabled-symbolic");
-        }
-
-        @keyframes disabled {
-            0% { -gtk-icon-source: -gtk-icontheme("notification-symbolic"); }
-            10% { -gtk-icon-source: -gtk-icontheme("notification-disabled-10-symbolic"); opacity: 0.94; }
-            20% { -gtk-icon-source: -gtk-icontheme("notification-disabled-20-symbolic"); opacity: 0.78; }
-            30% { -gtk-icon-source: -gtk-icontheme("notification-disabled-30-symbolic"); opacity: 0.82; }
-            40% { -gtk-icon-source: -gtk-icontheme("notification-disabled-40-symbolic"); opacity: 0.76; }
-            50% { -gtk-icon-source: -gtk-icontheme("notification-disabled-50-symbolic"); opacity: 0.70; }
-            60% { -gtk-icon-source: -gtk-icontheme("notification-disabled-60-symbolic"); opacity: 0.64; }
-            70% { -gtk-icon-source: -gtk-icontheme("notification-disabled-70-symbolic"); opacity: 0.58; }
-            80% { -gtk-icon-source: -gtk-icontheme("notification-disabled-80-symbolic"); opacity: 0.52; }
-            90% { -gtk-icon-source: -gtk-icontheme("notification-disabled-90-symbolic"); opacity: 0.46; }
-            100% { -gtk-icon-source: -gtk-icontheme("notification-disabled-symbolic"); }
-        }
-
-        @keyframes new {
-            0% { -gtk-icon-source: -gtk-icontheme("notification-symbolic"); }
-            10% { -gtk-icon-source: -gtk-icontheme("notification-new-10-symbolic"); }
-            20% { -gtk-icon-source: -gtk-icontheme("notification-new-20-symbolic"); }
-            30% { -gtk-icon-source: -gtk-icontheme("notification-new-30-symbolic"); }
-            40% { -gtk-icon-source: -gtk-icontheme("notification-new-40-symbolic"); }
-            50% { -gtk-icon-source: -gtk-icontheme("notification-new-50-symbolic"); }
-            60% { -gtk-icon-source: -gtk-icontheme("notification-new-60-symbolic"); }
-            70% { -gtk-icon-source: -gtk-icontheme("notification-new-70-symbolic"); }
-            80% { -gtk-icon-source: -gtk-icontheme("notification-new-80-symbolic"); }
-            90% { -gtk-icon-source: -gtk-icontheme("notification-new-90-symbolic"); }
-            100% { -gtk-icon-source: -gtk-icontheme("notification-new-symbolic"); }
-        }
-    """;
-
     public Indicator () {
         Object (code_name: Wingpanel.Indicator.MESSAGES,
                 display_name: _("Notifications indicator"),
@@ -101,12 +53,8 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             dynamic_icon.get_style_context ().add_class ("notification-icon");
 
             var provider = new Gtk.CssProvider ();
-            try {
-                provider.load_from_data (ICON_CSS, ICON_CSS.length);
-                Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-            } catch (Error e) {
-                critical (e.message);
-            }
+            provider.load_from_resource ("io/elementary/wingpanel/notifications/indicator.css");
+            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
 
         set_display_icon_name ();


### PR DESCRIPTION
animating icons with Gtk.CSS.

- [x] It requires this icons branch: https://github.com/elementary/icons/pull/370
- [x] and this stylesheet branch: https://github.com/elementary/stylesheet/pull/235

I'm using a Gtk.Spinner here because it can be used with `-gtk-icon-source`. It doesn't seem Gtk.Image works with it which is weird. I can't use the `background-image` property because it doesn't respect `-gtk-icon-shadow`.