### PR TITLE
debian: Remove dbus-glib dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,6 @@ Maintainer: elementary LLC <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
                gettext,
                gobject-introspection,
-               libdbus-glib-1-dev,
                libgdk-pixbuf2.0-dev,
                libglib2.0-dev,
                libgranite-dev,


### PR DESCRIPTION
As per @danrabbit request
> Hm it looks like dbus-glib is mentioned in the packaging. If this isn't necessary we should make sure to remove it from there as well