### PR TITLE
Remove Wnck

### DIFF
--- a/data/notifications.appdata.xml.in
+++ b/data/notifications.appdata.xml.in
@@ -6,6 +6,11 @@
   <name>Notifications Indicator</name>
   <summary>See missed notifications in the panel</summary>
   <releases>
+    <release version="2.2.0" date="2019-11-20" urgency="medium">
+      <description>
+        <p>Fix issues with disappearing notifications</p>
+      </description>
+    </release>
     <release version="2.1.3" date="2019-11-06" urgency="medium">
       <description>
         <p>Fix a minor visual inconsistency</p>

--- a/meson.build
+++ b/meson.build
@@ -43,7 +43,6 @@ shared_module(
         dependency('gobject-2.0'),
         dependency('granite'),
         dependency('gtk+-3.0'),
-        dependency('libwnck-3.0'),
         wingpanel_dep
     ],
     install: true,

--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -138,20 +138,6 @@ public class Notifications.Notification : Object {
         return false;
     }
 
-    public Wnck.Window? get_app_window () {
-        Wnck.Window? window = null;
-        if (pid_acquired) {
-            Wnck.Screen.get_default ().get_windows ().foreach ((_window) => {
-                if (_window.get_pid () == pid && window == null) {
-                    window = _window;
-                    return;
-                }
-            });
-        }
-
-        return window;
-    }
-
     private void setup_pid () {
         pid_acquired = try_get_pid ();
         Indicator.notify_settings.changed["do-not-disturb"].connect (() => {

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -68,15 +68,6 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
         show_all ();
     }
 
-    public Wnck.Window? get_app_window () {
-        if (app_notifications.length () == 0) {
-            return null;
-        }
-
-        var entry = app_notifications.first ().data;
-        return entry.notification.get_app_window ();
-    }
-
     public void add_notification_entry (NotificationEntry entry) {
         app_notifications.prepend (entry);
         entry.clear.connect (remove_notification_entry);

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -35,8 +35,6 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
         vexpand = true;
         show_all ();
-
-        monitor_active_window ();
     }
 
     construct {
@@ -152,17 +150,6 @@ public class Notifications.NotificationsList : Gtk.ListBox {
         return app_entry;
     }
 
-    private void monitor_active_window () {
-        var screen = Wnck.Screen.get_default ();
-        screen.active_window_changed.connect (() => {
-            app_entries.foreach ((app_entry) => {
-                if (screen.get_active_window () == app_entry.get_app_window ()) {
-                    app_entry.clear ();
-                }
-            });
-        });
-    }
-
     private void clear_app_entry (AppEntry app_entry) {
         app_entries.remove (app_entry);
 
@@ -203,19 +190,12 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
         if (row is AppEntry) {
             var app_entry = (AppEntry)row;
-            close = focus_notification_app (app_entry.get_app_window (),
-                                            app_entry.app_info);
-
             app_entry.clear ();
+
         } else if (row is NotificationEntry) {
             var notification_entry = (NotificationEntry)row;
-
-            if (!notification_entry.notification.run_default_action ()) {
-                close = focus_notification_app (notification_entry.notification.get_app_window (),
-                                                notification_entry.notification.app_info);
-            }
-
             notification_entry.clear ();
+
         } else {
             close = false;
         }
@@ -225,21 +205,5 @@ public class Notifications.NotificationsList : Gtk.ListBox {
         }
 
         update_separators ();
-    }
-
-    private bool focus_notification_app (Wnck.Window? app_window, AppInfo? app_info) {
-        if (app_window != null) {
-            app_window.activate (Gtk.get_current_event_time ());
-            return true;
-        } else if (app_info != null) {
-            try {
-                app_info.launch (null, null);
-                return true;
-            } catch (Error e) {
-                warning ("%s\n", e.message);
-            }
-        }
-
-        return false;
     }
 }


### PR DESCRIPTION
Fixes #68 
Fixes #10 

Drop the cutesy Wnck stuff. If notifications should be removed, the app can withdraw them or we can do something at the notification server level to withdraw notifications.