### PR TITLE
NotificationEntry: Copy line length and truncate rules

### DIFF
--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -74,7 +74,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
                 string[] lines = body.split ("\n");
                 string stripped_body = lines[0] + "\n";
                 for (int i = 1; i < lines.length; i++) {
-                    stripped_body += lines[i].strip () + "";
+                    stripped_body += lines[i].strip () + " ";
                 }
 
                 body_label.label = stripped_body.strip ();

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -40,33 +40,48 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         hexpand = true;
         get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
 
-        var title_label = new Gtk.Label ("<b>" + fix_markup (notification.summary) + "</b>");
+        var title_label = new Gtk.Label ("<b>%s</b>".printf (fix_markup (notification.summary)));
+        title_label.ellipsize = Pango.EllipsizeMode.END;
         title_label.hexpand = true;
-        title_label.max_width_chars = 32;
+        title_label.width_chars = 33;
+        title_label.max_width_chars = 33;
         title_label.use_markup = true;
-        title_label.wrap = true;
-        title_label.wrap_mode = Pango.WrapMode.WORD;
         title_label.xalign = 0;
 
         var time_label = new Gtk.Label (_("now"));
+        time_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
         var grid = new Gtk.Grid ();
         grid.margin_start = 40;
         grid.margin_end = 6;
-        grid.attach (title_label, 0, 0, 1, 1);
-        grid.attach (time_label, 1, 0, 1, 1);
+        grid.attach (title_label, 0, 0);
+        grid.attach (time_label, 1, 0);
 
         var entry_body = notification.message_body;
         if (entry_body != "") {
-            var body_label = new Gtk.Label (fix_markup (entry_body));
-            body_label.xalign = 0;
-            body_label.margin_bottom = 6;
-            body_label.margin_end = 3;
-            body_label.max_width_chars = 32;
+            var body = fix_markup (entry_body);
+
+            var body_label = new Gtk.Label (body);
+            body_label.ellipsize = Pango.EllipsizeMode.END;
+            body_label.lines = 2;
             body_label.use_markup = true;
-            body_label.wrap = true;
+            body_label.valign = Gtk.Align.START;
             body_label.wrap_mode = Pango.WrapMode.WORD_CHAR;
-            grid.attach (body_label, 0, 1, 2, 1);
+            body_label.wrap = true;
+            body_label.xalign = 0;
+
+            if ("\n" in body) {
+                string[] lines = body.split ("\n");
+                string stripped_body = lines[0] + "\n";
+                for (int i = 1; i < lines.length; i++) {
+                    stripped_body += lines[i].strip () + "";
+                }
+
+                body_label.label = stripped_body.strip ();
+                body_label.lines = 1;
+            }
+
+            grid.attach (body_label, 0, 1, 2);
         }
 
         add (grid);


### PR DESCRIPTION
Copies rules from https://github.com/elementary/notifications/blob/master/src/Bubble.vala#L102
* Consistent width: always 33ch wide
* Titles ellipsize, not wrap
* Body can be a maximum of 2 lines
* Forcefully remove extra new lines in body if necessary and truncate each line independently 

Also make timestamps dim label as we do in Mail