### PR TITLE
Indicator: Lookup io.elementary.notifications recursively

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -45,9 +45,11 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     }
 
     static construct {
-        if (GLib.SettingsSchemaSource.get_default ().lookup ("io.elementary.notifications", false) != null) {
+        if (GLib.SettingsSchemaSource.get_default ().lookup ("io.elementary.notifications", true) != null) {
+            debug ("Using io.elementary.notifications server");
             notify_settings = new GLib.Settings ("io.elementary.notifications");
         } else {
+            debug ("Using notifications in gala");
             notify_settings = new GLib.Settings ("org.pantheon.desktop.gala.notifications");
         }
     }


### PR DESCRIPTION
The docs on  SettingsSchemaSource get_default say
```
The returned source may actually consist of multiple schema sources from different directories, depending on which directories were given in `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR`. For this reason, all lookups performed against the default source should probably be done recursively.
```

Without this in NixOS, it will always use gala notifications
because recursion is required. It would be nice if any new code
in Pantheon always works like this to support NixOS properly.

---

I noticed this in https://github.com/elementary/notifications/issues/62#issuecomment-609579829.