### PR TITLE
Notification: Remove unix time property

### DIFF
--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -32,7 +32,6 @@ public class Notifications.Notification : Object {
     public uint32 id;
     public uint32 pid = 0;
     public GLib.DateTime timestamp;
-    public int64 unix_time;
 
     public string desktop_id;
     public DesktopAppInfo? app_info = null;
@@ -75,7 +74,6 @@ public class Notifications.Notification : Object {
 
         actions = body.get_child_value (Column.ACTIONS).dup_strv ();
         timestamp = new GLib.DateTime.now_local ();
-        unix_time = timestamp.to_unix ();
 
         desktop_id = lookup_string (hints, DESKTOP_ENTRY_KEY);
         if (desktop_id != "" && !desktop_id.has_suffix (DESKTOP_ID_EXT)) {
@@ -109,8 +107,7 @@ public class Notifications.Notification : Object {
         sender = _sender;
 
         actions = _actions;
-        unix_time = _unix_time;
-        timestamp = new GLib.DateTime.from_unix_local (unix_time);
+        timestamp = new GLib.DateTime.from_unix_local (_unix_time);
 
         desktop_id = _desktop_id;
         app_info = new DesktopAppInfo (desktop_id);

--- a/src/Services/Session.vala
+++ b/src/Services/Session.vala
@@ -89,7 +89,7 @@ public class Notifications.Session : GLib.Object {
         key.set_string (id, BODY_KEY, notification.message_body);
         key.set_string_list (id, ACTIONS_KEY, notification.actions);
         key.set_string (id, DESKTOP_ID_KEY, notification.desktop_id);
-        key.set_int64 (id, UNIX_TIME_KEY, notification.unix_time);
+        key.set_int64 (id, UNIX_TIME_KEY, notification.timestamp.to_unix ());
         key.set_string (id, SENDER_KEY, notification.sender);
 
         write_contents ();


### PR DESCRIPTION
Since this is only used for saving the session, we can convert from GLib.DateTime on save and restore. This doesn't need to be a property