### PR TITLE
Notification: Remove data session property

### DIFF
--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -18,8 +18,6 @@
 public class Notifications.Notification : Object {
     public const string DESKTOP_ID_EXT = ".desktop";
 
-    public bool data_session;
-
     public string app_name;
     public string summary;
     public string message_body;
@@ -61,8 +59,6 @@ public class Notifications.Notification : Object {
     public Notification.from_message (DBusMessage message, uint32 _id) {
         var body = message.get_body ();
 
-        data_session = false;
-
         app_name = get_string (body, Column.APP_NAME);
         app_icon = get_string (body, Column.APP_ICON);
         summary = get_string (body, Column.SUMMARY);
@@ -95,7 +91,6 @@ public class Notifications.Notification : Object {
     public Notification.from_data (uint32 _id, string _app_name, string _app_icon,
                                 string _summary, string _message_body,
                                 string[] _actions, string _desktop_id, int64 _unix_time, string _sender) {
-        data_session = true;
 
         app_name = _app_name;
         app_icon = _app_icon;

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -153,10 +153,6 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         show_all ();
 
-        if (notification.data_session) {
-            notification.time_changed (notification.timestamp);
-        }
-
         notification.time_changed.connect ((timestamp) => {
             time_label.label = Granite.DateTime.get_relative_datetime (timestamp);
 


### PR DESCRIPTION
We set the timestamp by default on construct so this doesn't appear to do anything