### PR TITLE
[Desktop] Per-notification Delete Button

### DIFF
--- a/data/NotificationEntry.css
+++ b/data/NotificationEntry.css
@@ -18,6 +18,14 @@
     border-bottom-left-radius: 6px;
 }
 
+.delete-affordance.neutral {
+    border-top-left-radius: 6px;
+    border-bottom-left-radius: 6px;
+    border-top-right-radius: 6px;
+    border-bottom-right-radius: 6px;
+    padding: 6px;
+}
+
 .delete-affordance image,
 .delete-affordance label {
     color: mix(@theme_fg_color, @error_color, 0.6);

--- a/data/NotificationEntry.css
+++ b/data/NotificationEntry.css
@@ -24,18 +24,27 @@
     font-weight: 600;
 }
 
-.delete-affordance-button {
-    background-color: mix(@theme_bg_color, @STRAWBERRY_500, 0.3);
-    box-shadow: none;
-    padding: 6px;
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+.close {
+    padding: 3px;
+    border: none;
+    border-radius: 100%;
+    background-image:
+        linear-gradient(
+            to bottom,
+            @BLACK_300,
+            @BLACK_500
+        );
+    box-shadow:
+        inset 0 0 0 1px alpha (#fff, 0.02),
+        inset 0 1px 0 0 alpha (#fff, 0.07),
+        inset 0 -1px 0 0 alpha (#fff, 0.01),
+        0 0 0 1px alpha (#000, 0.7),
+        0 1px 2px alpha (#000, 0.16),
+        0 2px 3px alpha (#000, 0.23);
+    margin: 3px;
 }
 
-.delete-affordance-button image,
-.delete-affordance-button label {
-    color: mix(@theme_fg_color, @error_color, 0.6);
-    font-weight: 600;
+.close-image {
+    color: #fff;
+    -gtk-icon-shadow: 0 1px 1px alpha (#000, 0.6);
 }

--- a/data/NotificationEntry.css
+++ b/data/NotificationEntry.css
@@ -44,7 +44,7 @@
     margin: 3px;
 }
 
-.close-image {
+.close image {
     color: #fff;
     -gtk-icon-shadow: 0 1px 1px alpha (#000, 0.6);
 }

--- a/data/NotificationEntry.css
+++ b/data/NotificationEntry.css
@@ -18,16 +18,24 @@
     border-bottom-left-radius: 6px;
 }
 
-.delete-affordance.neutral {
+.delete-affordance image,
+.delete-affordance label {
+    color: mix(@theme_fg_color, @error_color, 0.6);
+    font-weight: 600;
+}
+
+.delete-affordance-button {
+    background-color: mix(@theme_bg_color, @STRAWBERRY_500, 0.3);
+    box-shadow: none;
+    padding: 6px;
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
-    padding: 6px;
 }
 
-.delete-affordance image,
-.delete-affordance label {
+.delete-affordance-button image,
+.delete-affordance-button label {
     color: mix(@theme_fg_color, @error_color, 0.6);
     font-weight: 600;
 }

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -194,7 +194,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         });
 
         eventbox.leave_notify_event.connect ((event) => {
-            delete_revealer.set_reveal_child (false);
+            delete_revealer.reveal_child = false;
             return Gdk.EVENT_STOP;
         });
 

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -76,6 +76,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         var grid = new Gtk.Grid () {
             hexpand = true,
             column_spacing = 6,
+            row_homogeneous = true,
             margin = 12,
             // Box shadow is clipped to the margin area
             margin_top = 1,
@@ -86,42 +87,23 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         grid_context.add_class (Granite.STYLE_CLASS_CARD);
         grid_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        var delete_box = new DeleteAffordanceButton (Gtk.Align.CENTER);
-        delete_box.get_style_context ().add_class ("neutral");
+        var delete_box = new DeleteAffordanceButton ();
 
         delete_box.clicked.connect (() => {
             clear ();
         });
 
         var delete_revealer = new Gtk.Revealer () {
+            reveal_child = false,
             transition_duration = 200,
-            transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT
+            transition_type = Gtk.RevealerTransitionType.SLIDE_UP
         };
         delete_revealer.add (delete_box);
 
-        var delete_revealer_eventbox = new Gtk.EventBox () {
-            margin_start = margin_end = 6,
-            hexpand = true
-        };
-        delete_revealer_eventbox.events |= Gdk.EventMask.ENTER_NOTIFY_MASK &
-                       Gdk.EventMask.LEAVE_NOTIFY_MASK;
-
-        delete_revealer_eventbox.enter_notify_event.connect ((event) => {
-            delete_revealer.set_reveal_child (true);
-	        return false;
-        });
-
-        delete_revealer_eventbox.leave_notify_event.connect ((event) => {
-             delete_revealer.set_reveal_child (false);
-	        return false;
-        });
-
-        delete_revealer_eventbox.add (delete_revealer);
-
         grid.attach (app_image, 0, 0, 1, 2);
-        grid.attach (title_label, 1, 0);
-        grid.attach (time_label, 2, 0);
-        grid.attach (delete_revealer_eventbox, 3, 0);
+        grid.attach (title_label, 1, 0, 1, 1);
+        grid.attach (time_label, 2, 0, 1, 1);
+        grid.attach (delete_revealer, 2, 1, 1, 1);
 
         var entry_body = notification.message_body;
         if (entry_body != "") {
@@ -183,7 +165,25 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         };
         revealer.add (deck);
 
-        add (revealer);
+        var eventbox = new Gtk.EventBox ();
+        eventbox.events |= Gdk.EventMask.ENTER_NOTIFY_MASK &
+                           Gdk.EventMask.LEAVE_NOTIFY_MASK;
+
+        eventbox.enter_notify_event.connect ((event) => {
+            delete_revealer.set_reveal_child (true);
+            delete_revealer.no_show_all = false;
+            return false;
+        });
+
+        eventbox.leave_notify_event.connect ((event) => {
+            delete_revealer.set_reveal_child (false);
+            delete_revealer.no_show_all = true;
+            return false;
+        });
+
+        eventbox.add (revealer);
+
+        add (eventbox);
 
         show_all ();
 
@@ -256,12 +256,6 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
     }
 
     private class DeleteAffordanceButton : Gtk.Button {
-        public Gtk.Align alignment { get; construct; }
-
-        public DeleteAffordanceButton (Gtk.Align alignment) {
-            Object (alignment: alignment);
-        }
-
         construct {
             var image = new Gtk.Image.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
             image.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
@@ -271,20 +265,14 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
             };
             label.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-            var delete_internal_grid = new Gtk.Grid () {
-                halign = alignment,
-                hexpand = true,
-                row_spacing = 3,
-                valign = Gtk.Align.CENTER,
-                vexpand = true
-            };
+            var delete_internal_grid = new Gtk.Grid ();
             delete_internal_grid.attach (image, 0, 0);
-            delete_internal_grid.attach (label, 0, 1);
+            delete_internal_grid.attach (label, 1, 0);
 
             add (delete_internal_grid);
 
             unowned Gtk.StyleContext context = get_style_context ();
-            context.add_class ("delete-affordance");
+            context.add_class ("delete-affordance-button");
             context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
     }

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -205,13 +205,13 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         notification.closed.connect (() => clear ());
 
         deck.notify["visible-child"].connect (() => {
-            if (deck.transition_running == false && deck.visible_child != grid) {
+            if (deck.transition_running == false && deck.visible_child != overlay) {
                 clear ();
             }
         });
 
         deck.notify["transition-running"].connect (() => {
-            if (deck.transition_running == false && deck.visible_child != grid) {
+            if (deck.transition_running == false && deck.visible_child != overlay) {
                 clear ();
             }
         });

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -55,8 +55,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         var app_image = new Gtk.Image () {
             icon_name = app_icon,
-            pixel_size = 48,
-            valign = Gtk.Align.CENTER
+            pixel_size = 48
         };
 
         var title_label = new Gtk.Label ("<b>%s</b>".printf (fix_markup (notification.summary))) {
@@ -70,8 +69,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
 
         var time_label = new Gtk.Label (Granite.DateTime.get_relative_datetime (notification.timestamp)) {
-            margin_end = 6,
-            halign = Gtk.Align.END
+            margin_end = 6
         };
         time_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
@@ -91,20 +89,20 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         var delete_image = new Gtk.Image.from_icon_name ("window-close-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
         delete_image.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        var delete_box = new Gtk.Button () {
+        var delete_button = new Gtk.Button () {
             halign = Gtk.Align.START,
             valign = Gtk.Align.START,
             image = delete_image
         };
-        delete_box.get_style_context ().add_class ("close");
-        delete_box.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        delete_button.get_style_context ().add_class ("close");
+        delete_button.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var delete_revealer = new Gtk.Revealer () {
             reveal_child = false,
             transition_duration = Granite.TRANSITION_DURATION_CLOSE,
             transition_type = Gtk.RevealerTransitionType.CROSSFADE
         };
-        delete_revealer.add (delete_box);
+        delete_revealer.add (delete_button);
 
         grid.attach (app_image, 0, 0, 1, 2);
         grid.attach (title_label, 1, 0);
@@ -184,7 +182,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         show_all ();
 
-        delete_box.clicked.connect (() => {
+        delete_button.clicked.connect (() => {
             clear ();
         });
 

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -88,7 +88,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         grid_context.add_class (Granite.STYLE_CLASS_CARD);
         grid_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        var delete_image = new Gtk.Image.from_icon_name ("window-close-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        var delete_image = new Gtk.Image.from_icon_name ("window-close-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
         delete_image.get_style_context ().add_class ("close-image");
         delete_image.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -106,7 +106,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         var delete_revealer = new Gtk.Revealer () {
             reveal_child = false,
-            transition_duration = 200,
+            transition_duration = Granite.TRANSITION_DURATION_CLOSE,
             transition_type = Gtk.RevealerTransitionType.SLIDE_UP
         };
         delete_revealer.add (delete_box);

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -185,7 +185,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         eventbox.enter_notify_event.connect ((event) => {
             delete_revealer.reveal_child = true;
-            return false;
+            return Gdk.EVENT_STOP;
         });
 
         eventbox.leave_notify_event.connect ((event) => {

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -55,7 +55,8 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         var app_image = new Gtk.Image () {
             icon_name = app_icon,
-            pixel_size = 48
+            pixel_size = 48,
+            valign = Gtk.Align.START
         };
 
         var title_label = new Gtk.Label ("<b>%s</b>".printf (fix_markup (notification.summary))) {
@@ -69,7 +70,8 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
 
         var time_label = new Gtk.Label (Granite.DateTime.get_relative_datetime (notification.timestamp)) {
-            margin_end = 6
+            margin_end = 6,
+            halign = Gtk.Align.END
         };
         time_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
@@ -87,7 +89,11 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         grid_context.add_class (Granite.STYLE_CLASS_CARD);
         grid_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        var delete_box = new DeleteAffordanceButton ();
+        var delete_box = new DeleteAffordanceButton (Gtk.Align.START) {
+            // Have to match with the grid
+            margin_end = 1,
+            margin_start = 11
+        };
 
         delete_box.clicked.connect (() => {
             clear ();
@@ -256,6 +262,12 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
     }
 
     private class DeleteAffordanceButton : Gtk.Button {
+        public Gtk.Align alignment { get; construct; }
+
+        public DeleteAffordanceButton (Gtk.Align alignment) {
+            Object (alignment: alignment);
+        }
+
         construct {
             var image = new Gtk.Image.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
             image.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
@@ -265,7 +277,13 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
             };
             label.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-            var delete_internal_grid = new Gtk.Grid ();
+            var delete_internal_grid = new Gtk.Grid () {
+                halign = alignment,
+                hexpand = true,
+                row_spacing = 3,
+                valign = Gtk.Align.CENTER,
+                vexpand = true
+            };
             delete_internal_grid.attach (image, 0, 0);
             delete_internal_grid.attach (label, 1, 0);
 

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -56,7 +56,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         var app_image = new Gtk.Image () {
             icon_name = app_icon,
             pixel_size = 48,
-            valign = Gtk.Align.START
+            valign = Gtk.Align.CENTER
         };
 
         var title_label = new Gtk.Label ("<b>%s</b>".printf (fix_markup (notification.summary))) {
@@ -78,10 +78,9 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         var grid = new Gtk.Grid () {
             hexpand = true,
             column_spacing = 6,
-            row_homogeneous = true,
             margin = 12,
             // Box shadow is clipped to the margin area
-            margin_top = 1,
+            margin_top = 14,
             margin_bottom = 11
         };
 
@@ -89,11 +88,17 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         grid_context.add_class (Granite.STYLE_CLASS_CARD);
         grid_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        var delete_box = new DeleteAffordanceButton (Gtk.Align.START) {
-            // Have to match with the grid
-            margin_end = 1,
-            margin_start = 11
+        var delete_image = new Gtk.Image.from_icon_name ("window-close-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        delete_image.get_style_context ().add_class ("close-image");
+        delete_image.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        var delete_box = new Gtk.Button () {
+            halign = Gtk.Align.START,
+            valign = Gtk.Align.START,
+            image = delete_image
         };
+        delete_box.get_style_context ().add_class ("close");
+        delete_box.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         delete_box.clicked.connect (() => {
             clear ();
@@ -107,9 +112,8 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         delete_revealer.add (delete_box);
 
         grid.attach (app_image, 0, 0, 1, 2);
-        grid.attach (title_label, 1, 0, 1, 1);
-        grid.attach (time_label, 2, 0, 1, 1);
-        grid.attach (delete_revealer, 2, 1, 1, 1);
+        grid.attach (title_label, 1, 0);
+        grid.attach (time_label, 2, 0);
 
         var entry_body = notification.message_body;
         if (entry_body != "") {
@@ -142,14 +146,14 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         var delete_left = new DeleteAffordance (Gtk.Align.END) {
             // Have to match with the grid
-            margin_top = 1,
+            margin_top = 14,
             margin_bottom = 11
         };
         delete_left.get_style_context ().add_class ("left");
 
         var delete_right = new DeleteAffordance (Gtk.Align.START) {
             // Have to match with the grid
-            margin_top = 1,
+            margin_top = 14,
             margin_bottom = 11
         };
         delete_right.get_style_context ().add_class ("right");
@@ -171,23 +175,25 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         };
         revealer.add (deck);
 
+        var overlay = new Gtk.Overlay ();
+        overlay.add (revealer);
+        overlay.add_overlay (delete_revealer);
+
         var eventbox = new Gtk.EventBox ();
         eventbox.events |= Gdk.EventMask.ENTER_NOTIFY_MASK &
                            Gdk.EventMask.LEAVE_NOTIFY_MASK;
 
         eventbox.enter_notify_event.connect ((event) => {
             delete_revealer.set_reveal_child (true);
-            delete_revealer.no_show_all = false;
             return false;
         });
 
         eventbox.leave_notify_event.connect ((event) => {
             delete_revealer.set_reveal_child (false);
-            delete_revealer.no_show_all = true;
             return false;
         });
 
-        eventbox.add (revealer);
+        eventbox.add (overlay);
 
         add (eventbox);
 
@@ -253,40 +259,6 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
             unowned Gtk.StyleContext context = get_style_context ();
             context.add_class ("delete-affordance");
-            context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-        }
-    }
-
-    private class DeleteAffordanceButton : Gtk.Button {
-        public Gtk.Align alignment { get; construct; }
-
-        public DeleteAffordanceButton (Gtk.Align alignment) {
-            Object (alignment: alignment);
-        }
-
-        construct {
-            var image = new Gtk.Image.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
-            image.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
-            var label = new Gtk.Label ("<small>%s</small>".printf (_("Delete"))) {
-                use_markup = true
-            };
-            label.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
-            var delete_internal_grid = new Gtk.Grid () {
-                halign = alignment,
-                hexpand = true,
-                row_spacing = 3,
-                valign = Gtk.Align.CENTER,
-                vexpand = true
-            };
-            delete_internal_grid.attach (image, 0, 0);
-            delete_internal_grid.attach (label, 1, 0);
-
-            add (delete_internal_grid);
-
-            unowned Gtk.StyleContext context = get_style_context ();
-            context.add_class ("delete-affordance-button");
             context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
     }

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -86,9 +86,43 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         grid_context.add_class (Granite.STYLE_CLASS_CARD);
         grid_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
+        var delete_box = new DeleteAffordanceButton (Gtk.Align.CENTER);
+        delete_box.get_style_context ().add_class ("neutral");
+
+        delete_box.clicked.connect (() => {
+            clear ();
+        });
+
+        var delete_revealer = new Gtk.Revealer () {
+            transition_duration = 200,
+            transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT
+        };
+        delete_revealer.add (delete_box);
+
+        var delete_revealer_eventbox = new Gtk.EventBox () {
+            margin_start = margin_end = 6,
+            hexpand = true
+        };
+        delete_revealer_eventbox.events |= Gdk.EventMask.ENTER_NOTIFY_MASK &
+                       Gdk.EventMask.LEAVE_NOTIFY_MASK;
+
+        delete_revealer_eventbox.enter_notify_event.connect ((event) => {
+            delete_revealer.set_reveal_child (true);
+	        return false;
+        });
+
+        delete_revealer_eventbox.leave_notify_event.connect ((event) => {
+             delete_revealer.set_reveal_child (false);
+	        return false;
+        });
+
+        delete_revealer_eventbox.add (delete_revealer);
+
         grid.attach (app_image, 0, 0, 1, 2);
         grid.attach (title_label, 1, 0);
         grid.attach (time_label, 2, 0);
+        grid.attach (delete_revealer_eventbox, 3, 0);
+
         var entry_body = notification.message_body;
         if (entry_body != "") {
             var body = fix_markup (entry_body);
@@ -191,6 +225,40 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         public Gtk.Align alignment { get; construct; }
 
         public DeleteAffordance (Gtk.Align alignment) {
+            Object (alignment: alignment);
+        }
+
+        construct {
+            var image = new Gtk.Image.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
+            image.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+            var label = new Gtk.Label ("<small>%s</small>".printf (_("Delete"))) {
+                use_markup = true
+            };
+            label.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+            var delete_internal_grid = new Gtk.Grid () {
+                halign = alignment,
+                hexpand = true,
+                row_spacing = 3,
+                valign = Gtk.Align.CENTER,
+                vexpand = true
+            };
+            delete_internal_grid.attach (image, 0, 0);
+            delete_internal_grid.attach (label, 0, 1);
+
+            add (delete_internal_grid);
+
+            unowned Gtk.StyleContext context = get_style_context ();
+            context.add_class ("delete-affordance");
+            context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        }
+    }
+
+    private class DeleteAffordanceButton : Gtk.Button {
+        public Gtk.Align alignment { get; construct; }
+
+        public DeleteAffordanceButton (Gtk.Align alignment) {
             Object (alignment: alignment);
         }
 

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -184,7 +184,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
                            Gdk.EventMask.LEAVE_NOTIFY_MASK;
 
         eventbox.enter_notify_event.connect ((event) => {
-            delete_revealer.set_reveal_child (true);
+            delete_revealer.reveal_child = true;
             return false;
         });
 

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -107,7 +107,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         var delete_revealer = new Gtk.Revealer () {
             reveal_child = false,
             transition_duration = Granite.TRANSITION_DURATION_CLOSE,
-            transition_type = Gtk.RevealerTransitionType.SLIDE_UP
+            transition_type = Gtk.RevealerTransitionType.CROSSFADE
         };
         delete_revealer.add (delete_box);
 


### PR DESCRIPTION
Adds the ability to remove one notification at a time while on Desktop. Other form factors untested.

Looks like this:
![Screenshot from 2020-10-21 18 08 21](https://user-images.githubusercontent.com/4886639/96787632-773ff800-13c8-11eb-99b7-6e2af4f6c2c4.png)

CAVEAT: Place of activation seems to be small (2 pixels :disappointed: ), and the layout of each notification becomes off... If you have any ideas to help fix this, do voice 'em in the comments/reviews.