### PR TITLE
Session: Save/Restore replaces_id

### DIFF
--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -88,7 +88,7 @@ public class Notifications.Notification : Object {
 
     public Notification.from_data (uint32 _id, string _app_name, string _app_icon,
                                 string _summary, string _message_body,
-                                string[] _actions, string _desktop_id, int64 _unix_time, string _sender) {
+                                string[] _actions, string _desktop_id, int64 _unix_time, uint64 _replaces_id, string _sender) {
         data_session = true;
 
         app_name = _app_name;
@@ -96,7 +96,7 @@ public class Notifications.Notification : Object {
         summary = _summary;
         message_body = _message_body;
         expire_timeout = -1;
-        replaces_id = 0;
+        replaces_id = (uint32) _replaces_id;
         id = _id;
         sender = _sender;
 

--- a/src/Services/Session.vala
+++ b/src/Services/Session.vala
@@ -27,14 +27,15 @@ public class Notifications.Session : GLib.Object {
 
     private File session_file = null;
 
-    private const string APP_NAME_KEY = "AppName";
-    private const string APP_ICON_KEY = "AppIcon";
-    private const string SUMMARY_KEY = "Summary";
-    private const string BODY_KEY = "Body";
     private const string ACTIONS_KEY = "Actions";
+    private const string APP_ICON_KEY = "AppIcon";
+    private const string APP_NAME_KEY = "AppName";
+    private const string BODY_KEY = "Body";
     private const string DESKTOP_ID_KEY = "DesktopID";
-    private const string UNIX_TIME_KEY = "UnixTime";
+    private const string REPLACES_ID_KEY = "ReplacesID";
     private const string SENDER_KEY = "Sender";
+    private const string SUMMARY_KEY = "Summary";
+    private const string UNIX_TIME_KEY = "UnixTime";
 
     private KeyFile key;
 
@@ -69,6 +70,7 @@ public class Notifications.Session : GLib.Object {
                                                             key.get_string_list (group, ACTIONS_KEY),
                                                             key.get_string (group, DESKTOP_ID_KEY),
                                                             key.get_int64 (group, UNIX_TIME_KEY),
+                                                            key.get_uint64 (group, REPLACES_ID_KEY),
                                                             key.get_string (group, SENDER_KEY));
                 list.append (notification);
             }
@@ -83,14 +85,15 @@ public class Notifications.Session : GLib.Object {
 
     public void add_notification (Notification notification) {
         string id = notification.id.to_string ();
-        key.set_string (id, APP_NAME_KEY, notification.app_name);
-        key.set_string (id, APP_ICON_KEY, notification.app_icon);
-        key.set_string (id, SUMMARY_KEY, notification.summary);
-        key.set_string (id, BODY_KEY, notification.message_body);
-        key.set_string_list (id, ACTIONS_KEY, notification.actions);
-        key.set_string (id, DESKTOP_ID_KEY, notification.desktop_id);
         key.set_int64 (id, UNIX_TIME_KEY, notification.timestamp.to_unix ());
+        key.set_string (id, APP_ICON_KEY, notification.app_icon);
+        key.set_string (id, APP_NAME_KEY, notification.app_name);
+        key.set_string (id, BODY_KEY, notification.message_body);
+        key.set_string (id, DESKTOP_ID_KEY, notification.desktop_id);
         key.set_string (id, SENDER_KEY, notification.sender);
+        key.set_string (id, SUMMARY_KEY, notification.summary);
+        key.set_string_list (id, ACTIONS_KEY, notification.actions);
+        key.set_uint64 (id, REPLACES_ID_KEY, notification.replaces_id);
 
         write_contents ();
     }


### PR DESCRIPTION
Turns out we were hardcoding this to `0`