### PR TITLE
Move UsesNotifications check to Notification

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -157,9 +157,6 @@ public class Notifications.Indicator : Wingpanel.Indicator {
         }
 
         string app_id = notification.desktop_id.replace (Notification.DESKTOP_ID_EXT, "");
-        if (!((DesktopAppInfo)notification.app_info).get_boolean ("X-GNOME-UsesNotifications")) {
-            app_id = "gala-other";
-        }
 
         Settings? app_settings = app_settings_cache.get (app_id);
 

--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -74,7 +74,7 @@ public class Notifications.Notification : Object {
             app_info = new DesktopAppInfo (desktop_id);
         }
 
-        if (app_info == null) {
+        if (app_info == null || !app_info.get_boolean ("X-GNOME-UsesNotifications")) {
             desktop_id = FALLBACK_DESKTOP_ID;
             app_info = new DesktopAppInfo (desktop_id);
         }


### PR DESCRIPTION
Avoid an issue with possibly null appinfo and only assign fallback ID in one place