### PR TITLE
Handle NotificationEntry construction in NotificationsList

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -61,7 +61,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
             var previous_session = Session.get_instance ().get_session_notifications ();
             previous_session.foreach ((notification) => {
-                nlist.add_entry (new NotificationEntry (notification));
+                nlist.add_entry (notification);
             });
 
             var provider = new Gtk.CssProvider ();
@@ -170,8 +170,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
         }
 
         if (app_settings == null || app_settings.get_boolean (REMEMBER_KEY)) {
-            var entry = new NotificationEntry (notification);
-            nlist.add_entry (entry);
+            nlist.add_entry (notification);
         }
 
         set_display_icon_name ();

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -42,11 +42,11 @@ public class Notifications.NotificationsList : Gtk.ListBox {
         row_activated.connect (on_row_activated);
     }
 
-    public void add_entry (NotificationEntry entry) {
-        if (entry.notification.app_info != null && entry.notification.app_info.get_id () != null) {
+    public void add_entry (Notification notification) {
+        if (notification.app_info != null && notification.app_info.get_id () != null) {
             AppEntry? app_entry = null;
 
-            unowned string entry_desktop_id = entry.notification.desktop_id;
+            unowned string entry_desktop_id = notification.desktop_id;
             foreach (unowned AppEntry _app_entry in app_entries) {
                 if (_app_entry.app_info.get_id () == entry_desktop_id) {
                     app_entry = _app_entry;
@@ -54,6 +54,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
                 }
             }
 
+            var entry = new NotificationEntry (notification);
             if (app_entry == null) {
                 app_entry = new AppEntry (entry);
 
@@ -73,7 +74,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
             show_all ();
 
-            Session.get_instance ().add_notification (entry.notification);
+            Session.get_instance ().add_notification (notification);
         }
     }
 


### PR DESCRIPTION
In the future when we support replaces, we don't always want to construct a new NotificationEntry every time we get a notification. Having this internal to the `add_entry` method means the notification list will be able to make a determination about whether to construct a new entry or not