### PR TITLE
Notification: add stop_timeout

### DIFF
--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -47,6 +47,8 @@ public class Notifications.Notification : Object {
         COUNT
     }
 
+    private uint timeout_id;
+
     private const string DEFAULT_ACTION = "default";
     private const string X_CANONICAL_PRIVATE_KEY = "x-canonical-private-synchronous";
     private const string DESKTOP_ENTRY_KEY = "desktop-entry";
@@ -103,11 +105,17 @@ public class Notifications.Notification : Object {
     }
 
     construct {
-        Timeout.add_seconds_full (Priority.DEFAULT, 60, source_func);
+        timeout_id = Timeout.add_seconds_full (Priority.DEFAULT, 60, () => {
+            return time_changed (timestamp);
+        });
     }
 
     public void close () {
         closed ();
+    }
+
+    public void stop_timeout () {
+        Source.remove (timeout_id);
     }
 
     public bool run_default_action () {
@@ -149,9 +157,5 @@ public class Notifications.Notification : Object {
         }
 
         return child.dup_string ();
-    }
-
-    private bool source_func () {
-        return time_changed (timestamp);
     }
 }

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -67,7 +67,6 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
 
     public async void remove_notification_entry (NotificationEntry entry) {
         app_notifications.remove (entry);
-        entry.active = false;
         entry.dismiss ();
 
         Session.get_instance ().remove_notification (entry.notification);

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -218,6 +218,8 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
     }
 
     public void dismiss () {
+        notification.stop_timeout ();
+
         revealer.notify["child-revealed"].connect (() => {
             if (!revealer.child_revealed) {
                 destroy ();


### PR DESCRIPTION
This does two things:

1. Makes it easier for me to implement "replaces" which I swear is coming eventually
2. Makes it explicit what the purpose of this thing is and make sure we do it whenever we remove a NotificationEntry