### PR TITLE
Fix notification icons

### DIFF
--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -58,7 +58,6 @@ public class Notifications.Notification : Object {
         var body = message.get_body ();
 
         app_name = get_string (body, Column.APP_NAME);
-        app_icon = get_string (body, Column.APP_ICON);
         summary = get_string (body, Column.SUMMARY);
         message_body = get_string (body, Column.BODY);
         var hints = body.get_child_value (Column.HINTS);
@@ -74,6 +73,15 @@ public class Notifications.Notification : Object {
             desktop_id += DESKTOP_ID_EXT;
 
             app_info = new DesktopAppInfo (desktop_id);
+        }
+
+        app_icon = get_string (body, Column.APP_ICON);
+        if (app_icon == "") {
+            if (app_info != null) {
+                app_icon = app_info.get_icon ().to_string ();
+            } else {
+                app_icon = "dialog-information";
+            }
         }
 
         if (app_info == null || !app_info.get_boolean ("X-GNOME-UsesNotifications")) {

--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -47,6 +47,8 @@ public class Notifications.Notification : Object {
         COUNT
     }
 
+    private uint timeout_id;
+
     private const string DEFAULT_ACTION = "default";
     private const string X_CANONICAL_PRIVATE_KEY = "x-canonical-private-synchronous";
     private const string DESKTOP_ENTRY_KEY = "desktop-entry";
@@ -103,11 +105,17 @@ public class Notifications.Notification : Object {
     }
 
     construct {
-        Timeout.add_seconds_full (Priority.DEFAULT, 60, source_func);
+        timeout_id = Timeout.add_seconds_full (Priority.DEFAULT, 60, () => {
+            return time_changed (timestamp);
+        });
     }
 
     public void close () {
         closed ();
+    }
+
+    public void stop_timeout () {
+        Source.remove (timeout_id);
     }
 
     public bool run_default_action () {
@@ -149,9 +157,5 @@ public class Notifications.Notification : Object {
         }
 
         return child.dup_string ();
-    }
-
-    private bool source_func () {
-        return time_changed (timestamp);
     }
 }

--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -76,12 +76,8 @@ public class Notifications.Notification : Object {
         }
 
         app_icon = get_string (body, Column.APP_ICON);
-        if (app_icon == "") {
-            if (app_info != null) {
-                app_icon = app_info.get_icon ().to_string ();
-            } else {
-                app_icon = "dialog-information";
-            }
+        if (app_icon == "" && app_info != null) {
+            app_icon = app_info.get_icon ().to_string ();
         }
 
         if (app_info == null || !app_info.get_boolean ("X-GNOME-UsesNotifications")) {

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -67,7 +67,6 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
 
     public async void remove_notification_entry (NotificationEntry entry) {
         app_notifications.remove (entry);
-        entry.active = false;
         entry.dismiss ();
 
         Session.get_instance ().remove_notification (entry.notification);

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -45,6 +45,9 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
     construct {
         var app_icon = notification.app_icon;
+        if (app_icon == "") {
+                app_icon = "dialog-information";
+        }
 
         var app_image = new Gtk.Image () {
             icon_name = app_icon,

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -218,6 +218,8 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
     }
 
     public void dismiss () {
+        notification.stop_timeout ();
+
         revealer.notify["child-revealed"].connect (() => {
             if (!revealer.child_revealed) {
                 destroy ();

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -45,13 +45,6 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
     construct {
         var app_icon = notification.app_icon;
-        if (app_icon == "") {
-            if (notification.app_info != null) {
-                app_icon = notification.app_info.get_icon ().to_string ();
-            } else {
-                app_icon = "dialog-information";
-            }
-        }
 
         var app_image = new Gtk.Image () {
             icon_name = app_icon,


### PR DESCRIPTION
`app_info` is never null, so this doesn't work as intended

This should fix notification icons for apps with no `app_info` that are trying to set an icon manually and actually fall back to `dialog-information` if none is available. Neat!

One problem you'll experience is that your restored notifications that were sent prior to this branch will all be `dialog-information` because we were never properly setting or storing these icons. But this won't happen for any new icons