### PR TITLE
AppEntry: Support null appinfo

### DIFF
--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -19,6 +19,7 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
     public signal void clear ();
 
     public NotificationEntry entry { get; construct; }
+    public string app_id { get; private set; default = "other"; }
     public AppInfo? app_info = null;
     public List<NotificationEntry> app_notifications;
 
@@ -37,13 +38,19 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
         var notification = entry.notification;
         app_info = notification.app_info;
 
-        var label = new Gtk.Label (app_info.get_name ());
+        string name = _("Other");
+        if (app_info != null) {
+            app_id = app_info.get_id ();
+            name = app_info.get_name ();
+        }
+
+        var label = new Gtk.Label (name);
         label.hexpand = true;
         label.xalign = 0;
         label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
         var clear_btn_entry = new Gtk.Button.from_icon_name ("edit-clear-all-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            tooltip_text = _("Clear all %s notifications").printf (app_info.get_name ())
+            tooltip_text = _("Clear all %s notifications").printf (name)
         };
         clear_btn_entry.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -19,7 +19,7 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
     public signal void clear ();
 
     public NotificationEntry entry { get; construct; }
-    public string app_id { get; private set; default = "other"; }
+    public string app_id { get; private set; }
     public AppInfo? app_info = null;
     public List<NotificationEntry> app_notifications;
 
@@ -38,10 +38,13 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
         var notification = entry.notification;
         app_info = notification.app_info;
 
-        string name = _("Other");
+        string name;
         if (app_info != null) {
             app_id = app_info.get_id ();
             name = app_info.get_name ();
+        } else {
+            app_id = "other";
+            name = _("Other");
         }
 
         var label = new Gtk.Label (name);

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -48,7 +48,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
             unowned string entry_desktop_id = notification.desktop_id;
             foreach (unowned AppEntry _app_entry in app_entries) {
-                if (_app_entry.app_info.get_id () == entry_desktop_id) {
+                if (_app_entry.app_id == entry_desktop_id) {
                     app_entry = _app_entry;
                     continue;
                 }
@@ -61,12 +61,12 @@ public class Notifications.NotificationsList : Gtk.ListBox {
                 app_entries.append (app_entry);
                 prepend (app_entry);
                 insert (entry, 1);
-                table.insert (app_entry.app_info.get_id (), 0);
+                table.insert (app_entry.app_id, 0);
             } else {
                 resort_app_entry (app_entry);
                 app_entry.add_notification_entry (entry);
 
-                int insert_pos = table.get (app_entry.app_info.get_id ());
+                int insert_pos = table.get (app_entry.app_id);
                 insert (entry, insert_pos + 1);
             }
 


### PR DESCRIPTION
Doesn't make anything else support `null` app info yet, but theoretically you should be able to construct an AppEntry without app_info now