### PR TITLE
Add notifications indicator tooltip

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -227,11 +227,11 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("No new notifications"));
                 break;
             case 1:
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("1 new notification from 1 app"));
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("1 new notification"));
                 break;
             default:
                 /* Anything else */
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u new notifications from %i apps".printf(number_of_notifications, nlist.app_entries.size)));
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({"MiddleButton"}, _("%u new notifications from %i apps".printf(number_of_notifications, nlist.app_entries.size)));
                 break;
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -231,7 +231,11 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 break;
             default:
                 /* Anything else */
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u notifications from %i apps".printf (number_of_notifications, nlist.app_entries.size)));
+                if (nlist.app_entries.size > 1) {
+                    dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u notifications from %i apps".printf (number_of_notifications, nlist.app_entries.size)));
+                } else {
+                    dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u notifications from %i app".printf (number_of_notifications, nlist.app_entries.size)));
+                }
                 break;
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -231,11 +231,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 break;
             default:
                 /* Anything else */
-                if (nlist.app_entries.size > 1) {
-                    dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u notifications from %i apps".printf (number_of_notifications, nlist.app_entries.size)));
-                } else {
-                    dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u notifications from %i app".printf (number_of_notifications, nlist.app_entries.size)));
-                }
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u notifications from %i %s".printf (number_of_notifications, nlist.app_entries.size, ngettext("app", "apps", nlist.app_entries.size))));
                 break;
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -238,8 +238,8 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 /// TRANSLATORS: A tooltip text for the indicator representing the number of notifications.
                 /// e.g. "2 notifications from 1 app" or "5 notifications from 3 apps"
                 description = _("%s from %s").printf (
-                    ngettext ("%u notification", "%u notifications", number_of_notifications).printf (number_of_notifications),
-                    ngettext ("%i app", "%i apps", number_of_apps).printf (number_of_apps)
+                    _(ngettext ("%u notification", "%u notifications", number_of_notifications)).printf (number_of_notifications),
+                    _(ngettext ("%i app", "%i apps", number_of_apps)).printf (number_of_apps)
                 );
                 break;
         }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -238,8 +238,8 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 /// TRANSLATORS: A tooltip text for the indicator representing the number of notifications.
                 /// e.g. "2 notifications from 1 app" or "5 notifications from 3 apps"
                 description = _("%s from %s").printf (
-                    _(ngettext ("%u notification", "%u notifications", number_of_notifications)).printf (number_of_notifications),
-                    _(ngettext ("%i app", "%i apps", number_of_apps)).printf (number_of_apps)
+                    dngettext ("notifications-indicator", "%u notification", "%u notifications", number_of_notifications).printf (number_of_notifications),
+                    dngettext ("notifications-indicator", "%i app", "%i apps", number_of_apps).printf (number_of_apps)
                 );
                 break;
         }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -214,7 +214,21 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     }
 
     private void update_tooltip () {
-        dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({Middle-click to enable Do Not Disturb}, _("Test"));
+        int number_of_notifications = 0;
+        int number_of_apps = 0;
+
+        switch (number_of_notifications) {
+            case 0:
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("No new notifications"));
+                break;
+            case 1:
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("1 new notification from 1 app"));
+                break;
+            default:
+                /* Anything else */
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%i new notifications from %i app".printf(number_of_notifications, number_of_apps)));
+                break;
+        }
     }
 }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -222,6 +222,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     private void update_tooltip () {
         uint number_of_notifications = Session.get_instance ().get_session_notifications ().length ();
+        int number_of_apps = nlist.app_entries.size;
 
         string description;
         string accel_label;
@@ -243,7 +244,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 break;
             default:
                 /* Anything else */
-                description = _("%u notifications from %i %s".printf (number_of_notifications, nlist.app_entries.size, ngettext ("app", "apps", nlist.app_entries.size)));
+                description = _("%u notifications from %i %s".printf (number_of_notifications, number_of_apps, ngettext ("app", "apps", number_of_apps)));
                 break;
         }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -222,15 +222,6 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     private void update_tooltip () {
         uint number_of_notifications = Session.get_instance ().get_session_notifications ().length ();
 
-        uint accel_key;
-        Gdk.ModifierType accel_mods;
-
-        Granite.mouse_accelerator_parse ("<Button1>a", out accel_key, out accel_mods);
-
-        debug ("Keyval debug: %u".printf(accel_key));
-        debug ("Keyval debug: %u".printf(accel_mods));
-        debug ("Keyval debug: %u".printf(Gdk.ModifierType.BUTTON3_MASK));
-
         switch (number_of_notifications) {
             case 0:
                 dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("No notifications"));
@@ -240,7 +231,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 break;
             default:
                 /* Anything else */
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({"<Button3>"}, _("%u notifications from %i %s".printf (number_of_notifications, nlist.app_entries.size, ngettext ("app", "apps", nlist.app_entries.size))));
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u notifications from %i %s".printf (number_of_notifications, nlist.app_entries.size, ngettext ("app", "apps", nlist.app_entries.size))));
                 break;
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -238,7 +238,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 /// TRANSLATORS: A tooltip text for the indicator representing the number of notifications.
                 /// e.g. "2 notifications from 1 app" or "5 notifications from 3  apps"
                 description = _("%s from %s".printf (
-                    ngettext ("%u notification", "%u notifications",  number_of_notifications).printf (number_of_notifications),
+                    ngettext ("%u notification", "%u notifications", number_of_notifications).printf (number_of_notifications),
                     ngettext ("%i app", "%i apps", number_of_apps).printf (number_of_apps)
                 ));
                 break;

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -224,14 +224,14 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
         switch (number_of_notifications) {
             case 0:
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("No new notifications"));
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("No notifications"));
                 break;
             case 1:
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("1 new notification"));
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("1 notification"));
                 break;
             default:
                 /* Anything else */
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u new notifications from %i apps".printf (number_of_notifications, nlist.app_entries.size)));
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u notifications from %i apps".printf (number_of_notifications, nlist.app_entries.size)));
                 break;
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -188,6 +188,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 }
             }
         }
+        update_tooltip ();
     }
 
     private void set_display_icon_name () {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -92,7 +92,6 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             nlist.remove.connect (set_display_icon_name);
 
             set_display_icon_name ();
-            update_tooltip ();
         }
 
         return dynamic_icon;
@@ -172,16 +171,10 @@ public class Notifications.Indicator : Wingpanel.Indicator {
         }
 
         set_display_icon_name ();
-        update_tooltip ();
     }
 
     private void update_clear_all_sensitivity () {
         clear_all_btn.sensitive = nlist.app_entries.size > 0;
-
-        /* Since update_clear_all_sensitivity() is called when
-        each notification bubble is removed, we can update
-        our tooltip here. */
-        update_tooltip ();
     }
 
     private void on_notification_closed (uint32 id) {
@@ -189,7 +182,6 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             foreach (var item in app_entry.app_notifications) {
                 if (item.notification.id == id) {
                     item.notification.close ();
-
                     return;
                 }
             }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -92,6 +92,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             nlist.remove.connect (set_display_icon_name);
 
             set_display_icon_name ();
+            update_tooltip ();
         }
 
         return dynamic_icon;
@@ -171,6 +172,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
         }
 
         set_display_icon_name ();
+        update_tooltip ();
     }
 
     private void update_clear_all_sensitivity () {
@@ -209,6 +211,10 @@ public class Notifications.Indicator : Wingpanel.Indicator {
         } catch (Error e) {
             warning ("Failed to open notifications settings: %s", e.message);
         }
+    }
+
+    private void update_tooltip () {
+        dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({Middle-click to enable Do Not Disturb}, _("Test"));
     }
 }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -214,33 +214,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     }
 
     private void update_tooltip () {
-        /* NOTE: To get the number of notifications,
-        I've counted the number of rows in nlist, which
-        corresponds to the number of notifications with
-        their corresponding groups, i.e.
-
-        AppCenter
-        15 updates are available for your system
-
-        Other
-        Some random notification from an app
-        Another random notification from another app
-
-        This corresponds to 5 entries in total (3 notifications
-        and 2 groupings). To get the number of notifications,
-        we take the total number of entries - number of groupings.
-
-        There could be cleaner ways of doing this, but I'm sticking
-        with this for now.
-        */
-
-        int number_of_notifications = 0;
-
-        nlist.get_children ().foreach ((widget) => {
-            number_of_notifications++;
-        });
-
-        number_of_notifications -= nlist.app_entries.size;
+        uint number_of_notifications = Session.get_instance ().get_session_notifications ().length ();
 
         switch (number_of_notifications) {
             case 0:
@@ -251,7 +225,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 break;
             default:
                 /* Anything else */
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%i new notifications from %i apps".printf(number_of_notifications, nlist.app_entries.size)));
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u new notifications from %i apps".printf(number_of_notifications, nlist.app_entries.size)));
                 break;
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -32,6 +32,9 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     public static GLib.Settings notify_settings;
 
+    private int number_of_notifications = 0;
+    private int number_of_apps = 0;
+
     public Indicator () {
         Object (code_name: Wingpanel.Indicator.MESSAGES);
 
@@ -226,7 +229,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 break;
             default:
                 /* Anything else */
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%i new notifications from %i app".printf(number_of_notifications, number_of_apps)));
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%i new notifications from %i apps".printf(number_of_notifications, number_of_apps)));
                 break;
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -231,7 +231,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 break;
             default:
                 /* Anything else */
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({"MiddleButton"}, _("%u new notifications from %i apps".printf (number_of_notifications, nlist.app_entries.size)));
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u new notifications from %i apps".printf (number_of_notifications, nlist.app_entries.size)));
                 break;
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -235,8 +235,12 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 description = _("1 notification");
                 break;
             default:
-                /* Anything else */
-                description = _("%u notifications from %i %s".printf (number_of_notifications, number_of_apps, ngettext ("app", "apps", number_of_apps)));
+                /// TRANSLATORS: A tooltip text for the indicator representing the number of notifications.
+                /// e.g. "2 notifications from 1 app" or "5 notifications from 3  apps"
+                description = _("%s from %s".printf (
+                    ngettext ("%u notification", "%u notifications",  number_of_notifications).printf (number_of_notifications),
+                    ngettext ("%i app", "%i apps", number_of_apps).printf (number_of_apps)
+                ));
                 break;
         }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -178,9 +178,9 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     private void update_clear_all_sensitivity () {
         clear_all_btn.sensitive = nlist.app_entries.size > 0;
 
-        /* Since update_clear_all_sensitivity() is called on
-        each popover remove, we can update our tooltip on
-        each popover remove here. */
+        /* Since update_clear_all_sensitivity() is called when
+        each notification bubble is removed, we can update
+        our tooltip here. */
         update_tooltip ();
     }
 
@@ -222,26 +222,32 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     private void update_tooltip () {
         uint number_of_notifications = Session.get_instance ().get_session_notifications ().length ();
+
+        string description;
         string accel_label;
 
         if (notify_settings.get_boolean ("do-not-disturb")) {
-            accel_label = """<span weight="600" size="smaller" alpha="75%">Middle-click to disable Do Not Disturb</span>""";
+            accel_label = _("Middle-click to disable Do Not Disturb");
         } else {
-            accel_label = """<span weight="600" size="smaller" alpha="75%">Middle-click to enable Do Not Disturb</span>""";
+            accel_label = _("Middle-click to enable Do Not Disturb");
         }
+
+        accel_label = """<span weight="600" size="smaller" alpha="75%">%s</span>""".printf (accel_label);
 
         switch (number_of_notifications) {
             case 0:
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("No notifications"));
+                description = _("No notifications");
                 break;
             case 1:
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("1 notification"));
+                description = _("1 notification");
                 break;
             default:
                 /* Anything else */
-                dynamic_icon.tooltip_markup = _("%u notifications from %i %s\n%s".printf (number_of_notifications, nlist.app_entries.size, ngettext ("app", "apps", nlist.app_entries.size), accel_label));
+                description = _("%u notifications from %i %s".printf (number_of_notifications, nlist.app_entries.size, ngettext ("app", "apps", nlist.app_entries.size)));
                 break;
         }
+
+        dynamic_icon.tooltip_markup = "%s\n%s".printf (description, accel_label);
     }
 }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -178,6 +178,9 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     private void update_clear_all_sensitivity () {
         clear_all_btn.sensitive = nlist.app_entries.size > 0;
 
+        /* Since update_clear_all_sensitivity() is called on
+        each popover remove, we can update our tooltip on
+        each popover remove here. */
         update_tooltip ();
     }
 
@@ -186,11 +189,11 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             foreach (var item in app_entry.app_notifications) {
                 if (item.notification.id == id) {
                     item.notification.close ();
+
                     return;
                 }
             }
         }
-        update_tooltip ();
     }
 
     private void set_display_icon_name () {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -236,11 +236,11 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 break;
             default:
                 /// TRANSLATORS: A tooltip text for the indicator representing the number of notifications.
-                /// e.g. "2 notifications from 1 app" or "5 notifications from 3  apps"
-                description = _("%s from %s".printf (
+                /// e.g. "2 notifications from 1 app" or "5 notifications from 3 apps"
+                description = _("%s from %s").printf (
                     ngettext ("%u notification", "%u notifications", number_of_notifications).printf (number_of_notifications),
                     ngettext ("%i app", "%i apps", number_of_apps).printf (number_of_apps)
-                ));
+                );
                 break;
         }
 

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -207,6 +207,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             dynamic_icon_style_context.remove_class ("disabled");
             dynamic_icon_style_context.remove_class ("new");
         }
+        update_tooltip ();
     }
 
     private void show_settings () {
@@ -221,6 +222,13 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     private void update_tooltip () {
         uint number_of_notifications = Session.get_instance ().get_session_notifications ().length ();
+        string accel_label;
+
+        if (notify_settings.get_boolean ("do-not-disturb")) {
+            accel_label = """<span weight="600" size="smaller" alpha="75%">Middle-click to disable Do Not Disturb</span>""";
+        } else {
+            accel_label = """<span weight="600" size="smaller" alpha="75%">Middle-click to enable Do Not Disturb</span>""";
+        }
 
         switch (number_of_notifications) {
             case 0:
@@ -231,7 +239,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 break;
             default:
                 /* Anything else */
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u notifications from %i %s".printf (number_of_notifications, nlist.app_entries.size, ngettext ("app", "apps", nlist.app_entries.size))));
+                dynamic_icon.tooltip_markup = _("%u notifications from %i %s\n%s".printf (number_of_notifications, nlist.app_entries.size, ngettext ("app", "apps", nlist.app_entries.size), accel_label));
                 break;
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -32,9 +32,6 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     public static GLib.Settings notify_settings;
 
-    private int number_of_notifications = 0;
-    private int number_of_apps = 0;
-
     public Indicator () {
         Object (code_name: Wingpanel.Indicator.MESSAGES);
 
@@ -217,8 +214,33 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     }
 
     private void update_tooltip () {
+        /* NOTE: To get the number of notifications,
+        I've counted the number of rows in nlist, which
+        corresponds to the number of notifications with
+        their corresponding groups, i.e.
+
+        AppCenter
+        15 updates are available for your system
+
+        Other
+        Some random notification from an app
+        Another random notification from another app
+
+        This corresponds to 5 entries in total (3 notifications
+        and 2 groupings). To get the number of notifications,
+        we take the total number of entries - number of groupings.
+
+        There could be cleaner ways of doing this, but I'm sticking
+        with this for now.
+        */
+
         int number_of_notifications = 0;
-        int number_of_apps = 0;
+
+        nlist.get_children ().foreach ((widget) => {
+            number_of_notifications++;
+        });
+
+        number_of_notifications -= nlist.app_entries.size;
 
         switch (number_of_notifications) {
             case 0:
@@ -229,7 +251,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 break;
             default:
                 /* Anything else */
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%i new notifications from %i apps".printf(number_of_notifications, number_of_apps)));
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%i new notifications from %i apps".printf(number_of_notifications, nlist.app_entries.size)));
                 break;
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -225,7 +225,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             accel_label = _("Middle-click to enable Do Not Disturb");
         }
 
-        accel_label = """<span weight="600" size="smaller" alpha="75%">%s</span>""".printf (accel_label);
+        accel_label = Granite.TOOLTIP_SECONDARY_TEXT_MARKUP.printf (accel_label);
 
         switch (number_of_notifications) {
             case 0:

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -222,6 +222,15 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     private void update_tooltip () {
         uint number_of_notifications = Session.get_instance ().get_session_notifications ().length ();
 
+        uint accel_key;
+        Gdk.ModifierType accel_mods;
+
+        Granite.mouse_accelerator_parse ("<Button1>a", out accel_key, out accel_mods);
+
+        debug ("Keyval debug: %u".printf(accel_key));
+        debug ("Keyval debug: %u".printf(accel_mods));
+        debug ("Keyval debug: %u".printf(Gdk.ModifierType.BUTTON3_MASK));
+
         switch (number_of_notifications) {
             case 0:
                 dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("No notifications"));
@@ -231,7 +240,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 break;
             default:
                 /* Anything else */
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({}, _("%u notifications from %i %s".printf (number_of_notifications, nlist.app_entries.size, ngettext("app", "apps", nlist.app_entries.size))));
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({"<Button3>"}, _("%u notifications from %i %s".printf (number_of_notifications, nlist.app_entries.size, ngettext ("app", "apps", nlist.app_entries.size))));
                 break;
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -231,7 +231,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 break;
             default:
                 /* Anything else */
-                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({"MiddleButton"}, _("%u new notifications from %i apps".printf(number_of_notifications, nlist.app_entries.size)));
+                dynamic_icon.tooltip_markup = Granite.markup_accel_tooltip ({"MiddleButton"}, _("%u new notifications from %i apps".printf (number_of_notifications, nlist.app_entries.size)));
                 break;
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -177,6 +177,8 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     private void update_clear_all_sensitivity () {
         clear_all_btn.sensitive = nlist.app_entries.size > 0;
+
+        update_tooltip ();
     }
 
     private void on_notification_closed (uint32 id) {


### PR DESCRIPTION
Closes #173.

### Demo
![Screenshot from 2020-12-08 03-50-22](https://user-images.githubusercontent.com/31680656/101398180-a672e000-3908-11eb-8474-4b7feb08d003.png)

<strike>As for showing middle-click to enable/disable DnD, I can't parse a mouse key to Granite.markup_accel_tooltip since it takes **keyboard** accelerators.</strike>