### PR TITLE
Use Granite.SwitchModelButton and Gtk.Separator

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -99,6 +99,11 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     public override Gtk.Widget? get_widget () {
         if (main_box == null) {
+            var dnd_switch_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
+                margin_top = 3,
+                margin_bottom = 3
+            };
+
             var scrolled = new Gtk.ScrolledWindow (null, null);
             scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
             scrolled.max_content_height = 500;
@@ -107,6 +112,11 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
             not_disturb_switch = new Granite.SwitchModelButton (_("Do Not Disturb"));
             not_disturb_switch.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+
+            var clear_all_btn_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
+                margin_top = 3,
+                margin_bottom = 3
+            };
 
             clear_all_btn = new Gtk.ModelButton ();
             clear_all_btn.text = _("Clear All Notifications");
@@ -118,9 +128,9 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             main_box.orientation = Gtk.Orientation.VERTICAL;
             main_box.width_request = 300;
             main_box.add (not_disturb_switch);
-            main_box.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
+            main_box.add (dnd_switch_separator);
             main_box.add (scrolled);
-            main_box.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
+            main_box.add (clear_all_btn_separator);
             main_box.add (clear_all_btn);
             main_box.add (settings_btn);
             main_box.show_all ();

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -118,9 +118,9 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             main_box.orientation = Gtk.Orientation.VERTICAL;
             main_box.width_request = 300;
             main_box.add (not_disturb_switch);
-            main_box.add (new Wingpanel.Widgets.Separator ());
+            main_box.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             main_box.add (scrolled);
-            main_box.add (new Wingpanel.Widgets.Separator ());
+            main_box.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             main_box.add (clear_all_btn);
             main_box.add (settings_btn);
             main_box.show_all ();

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -24,7 +24,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     private Gtk.Spinner? dynamic_icon = null;
     private Gtk.Grid? main_box = null;
     private Gtk.ModelButton clear_all_btn;
-    private Wingpanel.Widgets.Switch not_disturb_switch;
+    private Granite.SwitchModelButton not_disturb_switch;
 
     private NotificationsList nlist;
 
@@ -105,7 +105,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             scrolled.propagate_natural_height = true;
             scrolled.add (nlist);
 
-            not_disturb_switch = new Wingpanel.Widgets.Switch (_("Do Not Disturb"));
+            not_disturb_switch = new Granite.SwitchModelButton (_("Do Not Disturb"));
             not_disturb_switch.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
 
             clear_all_btn = new Gtk.ModelButton ();

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -99,6 +99,9 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
     public override Gtk.Widget? get_widget () {
         if (main_box == null) {
+            not_disturb_switch = new Granite.SwitchModelButton (_("Do Not Disturb"));
+            not_disturb_switch.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+
             var dnd_switch_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
                 margin_top = 3,
                 margin_bottom = 3
@@ -109,9 +112,6 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             scrolled.max_content_height = 500;
             scrolled.propagate_natural_height = true;
             scrolled.add (nlist);
-
-            not_disturb_switch = new Granite.SwitchModelButton (_("Do Not Disturb"));
-            not_disturb_switch.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
 
             var clear_all_btn_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
                 margin_top = 3,


### PR DESCRIPTION
Requires elementary/granite#474

`Wingpanel.Widgets.Switch` and `Wingpanel.Widgets.Separator` are deprecated.