### PR TITLE
Notification clearing fixes

### DIFF
--- a/src/Services/Session.vala
+++ b/src/Services/Session.vala
@@ -108,6 +108,18 @@ public class Notifications.Session : GLib.Object {
         write_contents ();
     }
 
+    public void remove_notifications (Notification[] notifications) {
+        foreach (unowned var notification in notifications) {
+            try {
+                key.remove_group (notification.id.to_string ());
+            } catch (KeyFileError e) {
+                warning (e.message);
+            }
+        }
+
+        write_contents ();
+    }
+
     public void clear () {
         try {
             FileUtils.set_contents (session_file.get_path (), "");

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -63,7 +63,7 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
         show_all ();
 
         clear_btn_entry.clicked.connect (() => {
-            clear ();
+            clear_all_notification_entries ();
         });
     }
 
@@ -72,7 +72,7 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
         entry.clear.connect (remove_notification_entry);
     }
 
-    public async void remove_notification_entry (NotificationEntry entry) {
+    public void remove_notification_entry (NotificationEntry entry) {
         app_notifications.remove (entry);
         entry.dismiss ();
 
@@ -80,5 +80,17 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
         if (app_notifications.length () == 0) {
             clear ();
         }
+    }
+
+    public void clear_all_notification_entries () {
+        Notification[] to_remove = {};
+        app_notifications.@foreach ((entry) => {
+            entry.dismiss ();
+            to_remove += entry.notification;
+        });
+
+        app_notifications = new List<NotificationEntry> ();
+        Session.get_instance ().remove_notifications (to_remove);
+        clear ();
     }
 }

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -80,10 +80,12 @@ public class Notifications.NotificationsList : Gtk.ListBox {
     }
 
     public void clear_all () {
-        app_entries.values.foreach ((app_entry) => {
-            clear_app_entry (app_entry);
-            return true;
-        });
+        var iter = app_entries.map_iterator ();
+        while (iter.next ()) {
+            var entry = iter.get_value ();
+            iter.unset ();
+            clear_app_entry (entry);
+        }
 
         close_popover ();
     }
@@ -100,11 +102,11 @@ public class Notifications.NotificationsList : Gtk.ListBox {
     }
 
     private void clear_app_entry (AppEntry app_entry) {
+        app_entry.clear.disconnect (clear_app_entry);
+
         app_entries.unset (app_entry.app_id);
 
-        app_entry.app_notifications.foreach ((notification_entry) => {
-            app_entry.remove_notification_entry.begin (notification_entry);
-        });
+        app_entry.clear_all_notification_entries ();
 
         app_entry.destroy ();
 


### PR DESCRIPTION
Fixes #174 

- Add a `remove_notifications` method to `Session` so that a bunch of notifications can be removed at once, with a single disk write instead of writing the changes to the disk in between each removal.
- Remove `async` that wasn't actually async
- Don't remove entries from a `HashMap` in a read-only foreach loop.
- Disconnect a clear signal handler to prevent circular signal emissions