### PR TITLE
Notification: Don't rewrite valid appinfo

### DIFF
--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -79,7 +79,7 @@ public class Notifications.Notification : Object {
             app_icon = app_info.get_icon ().to_string ();
         }
 
-        if (app_info == null || !app_info.get_boolean ("X-GNOME-UsesNotifications")) {
+        if (app_info == null) {
             desktop_id = FALLBACK_DESKTOP_ID;
             app_info = new DesktopAppInfo (desktop_id);
         }


### PR DESCRIPTION
If we're getting valid appinfo, we shouldn't force apps to be listed under "Other"