### PR TITLE
NotificationsList: Don't clear all on misclick

### DIFF
--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -111,22 +111,11 @@ public class Notifications.NotificationsList : Gtk.ListBox {
     }
 
     private void on_row_activated (Gtk.ListBoxRow row) {
-        bool close = true;
-
-        if (row is AppEntry) {
-            var app_entry = (AppEntry)row;
-            app_entry.clear ();
-
-        } else if (row is NotificationEntry) {
+        if (row is NotificationEntry) {
             unowned NotificationEntry notification_entry = (NotificationEntry) row;
             notification_entry.notification.run_default_action ();
             notification_entry.clear ();
 
-        } else {
-            close = false;
-        }
-
-        if (close) {
             close_popover ();
         }
     }


### PR DESCRIPTION
This is strangely convoluted. The only types of things packed into this listbox are either notifications or app headers, so there's no case where `close == false`. It also doesn't make sense to clear all notifications unless the user clicks the clear all button in the header. So really we only need to check if a notification has been activated here