### PR TITLE
NotificationsMonitor: Replace deprecated eavesdrop monitoring

### DIFF
--- a/src/Services/Interfaces.vala
+++ b/src/Services/Interfaces.vala
@@ -17,23 +17,5 @@
 
 [DBus (name = "org.freedesktop.Notifications")]
 public interface Notifications.INotifications : Object {
-    public signal void notification_closed (uint32 id, uint32 reason);
     public signal void action_invoked (uint32 id, string action);
-    public abstract uint32 notify (string app_name,
-                                uint32 replaces_id,
-                                string app_icon,
-                                string summary,
-                                string body,
-                                string[] actions,
-                                HashTable<string, Variant> hints,
-                                int32 expire_timeout) throws Error;
-}
-
-[DBus (name = "org.freedesktop.DBus")]
-public interface Notifications.IDBus : Object {
-    [DBus (name = "NameHasOwner")]
-    public abstract bool name_has_owner (string name) throws Error;
-
-    [DBus (name = "GetConnectionUnixProcessID")]
-    public abstract uint32 get_connection_unix_process_id (string name) throws Error;
 }


### PR DESCRIPTION
Fixes #210 

The eavesdropping method of listening to messages on the bus is deprecated according to the DBus docs https://dbus.freedesktop.org/doc/dbus-specification.html

The replacement is setting a private bus connection up as a "Monitor".

I've tested this restores the functionality of the notification indicator on Fedora, where nothing was happening, presumably due to newer versions of DBus or stricter blocking of the older eavesdropping method. I've also tested that this continues to work on Odin.

I've also replaced the `error` calls with more appropriate things. We shouldn't crash the whole of wingpanel just because notifications aren't working properly.