### PR TITLE
NotificationsMonitor: Support Vala 0.54+

### DIFF
--- a/src/Services/NotificationsMonitor.vala
+++ b/src/Services/NotificationsMonitor.vala
@@ -49,7 +49,11 @@ public class Notifications.NotificationMonitor : Object {
     private NotificationMonitor () {
         try {
             // Set up a private connection to the session bus
+#if VALA_0_54
+            string address = BusType.SESSION.get_address_sync ();
+#else
             string address = BusType.get_address_sync (BusType.SESSION);
+#endif
             connection = new DBusConnection.for_address_sync (
                 address,
                 DBusConnectionFlags.AUTHENTICATION_CLIENT | DBusConnectionFlags.MESSAGE_BUS_CONNECTION


### PR DESCRIPTION
This changed in https://gitlab.gnome.org/GNOME/vala/-/commit/9d5708923f64b3914aa213ca780973be853a03b7

@decathorpe Can you see if this fixes compilation for you on Fedora 35?