### PR TITLE
Load notifications more efficiently in a separate thread

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -49,11 +49,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             dynamic_icon.active = true;
 
             nlist = new NotificationsList ();
-
-            var previous_session = Session.get_instance ().get_session_notifications ();
-            previous_session.foreach ((notification) => {
-                nlist.add_entry (notification);
-            });
+            get_session_notifications.begin ();
 
             Gtk.IconTheme.get_default ().add_resource_path ("/io/elementary/wingpanel/notifications");
 
@@ -68,26 +64,41 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             monitor.notification_received.connect (on_notification_received);
             monitor.notification_closed.connect (on_notification_closed);
 
-            dynamic_icon.button_press_event.connect ((e) => {
-                if (e.button == Gdk.BUTTON_MIDDLE) {
-                    notify_settings.set_boolean ("do-not-disturb", !notify_settings.get_boolean ("do-not-disturb"));
-                    return Gdk.EVENT_STOP;
-                }
-
-                return Gdk.EVENT_PROPAGATE;
-            });
-
             notify_settings.changed["do-not-disturb"].connect (() => {
                 set_display_icon_name ();
             });
-
-            nlist.add.connect (set_display_icon_name);
-            nlist.remove.connect (set_display_icon_name);
-
-            set_display_icon_name ();
         }
 
         return dynamic_icon;
+    }
+
+    private async void get_session_notifications () throws ThreadError {
+        dynamic_icon.tooltip_markup = _("Updating session notifications.  Please wait");
+        dynamic_icon.get_style_context ().add_class ("disabled");
+
+        SourceFunc callback = get_session_notifications.callback;
+        ThreadFunc<bool> run = () => {
+            var previous_session = Session.get_instance ().get_session_notifications ();
+            previous_session.foreach ((notification) => {
+                nlist.add_entry (notification, false); // Do not need to write back to file
+            });
+            Idle.add ((owned)callback);
+            return true;
+        };
+        new Thread<bool> ("load-notifications", (owned)run);
+        yield;
+
+        nlist.add.connect (set_display_icon_name);
+        nlist.remove.connect (set_display_icon_name);
+        dynamic_icon.button_press_event.connect ((e) => {
+            if (e.button == Gdk.BUTTON_MIDDLE) {
+                notify_settings.set_boolean ("do-not-disturb", !notify_settings.get_boolean ("do-not-disturb"));
+                return Gdk.EVENT_STOP;
+            }
+
+            return Gdk.EVENT_PROPAGATE;
+        });
+        set_display_icon_name ();
     }
 
     public override Gtk.Widget? get_widget () {
@@ -216,7 +227,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     }
 
     private void update_tooltip () {
-        uint number_of_notifications = Session.get_instance ().get_session_notifications ().length ();
+        uint number_of_notifications = Session.get_instance ().count_notifications ();
         int number_of_apps = nlist.app_entries.size;
 
         string description;

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -46,7 +46,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
         row_activated.connect (on_row_activated);
     }
 
-    public void add_entry (Notification notification) {
+    public void add_entry (Notification notification, bool write_file = true) {
         var entry = new NotificationEntry (notification);
 
         if (app_entries[notification.desktop_id] != null) {
@@ -71,7 +71,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
         show_all ();
 
-        Session.get_instance ().add_notification (notification);
+        Session.get_instance ().add_notification (notification, write_file);
     }
 
     public void clear_all () {


### PR DESCRIPTION
Partially addresses #237 
Partially address #123 

This PR greatly improves the load speed of the wingpanel when there are thousands of sessions notifications.  The wingpanel's appearance is no longer blocked while the notification listbox is filled with entries.  The notification session file is no longer needlessly rewritten.  A faster function for counting the number of session notifications is provided. The function for getting a list of session notifications is sped up.