### PR TITLE
Clear notifications faster

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -52,7 +52,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
             var previous_session = Session.get_instance ().get_session_notifications ();
             previous_session.foreach ((notification) => {
-                nlist.add_entry (notification);
+                nlist.add_entry (notification, false);
             });
 
             Gtk.IconTheme.get_default ().add_resource_path ("/io/elementary/wingpanel/notifications");

--- a/src/Services/NotificationsMonitor.vala
+++ b/src/Services/NotificationsMonitor.vala
@@ -94,9 +94,7 @@ public class Notifications.NotificationMonitor : Object {
     }
 
     private DBusMessage? message_filter (DBusConnection con, owned DBusMessage message, bool incoming) {
-
         if (incoming && message.get_interface () == NOTIFY_IFACE && message.get_message_type () == DBusMessageType.METHOD_CALL) {
-
             if (message.get_member () == "Notify") {
                 try {
                     awaiting_reply = message.copy ();

--- a/src/Services/NotificationsMonitor.vala
+++ b/src/Services/NotificationsMonitor.vala
@@ -94,7 +94,9 @@ public class Notifications.NotificationMonitor : Object {
     }
 
     private DBusMessage? message_filter (DBusConnection con, owned DBusMessage message, bool incoming) {
+
         if (incoming && message.get_interface () == NOTIFY_IFACE && message.get_message_type () == DBusMessageType.METHOD_CALL) {
+
             if (message.get_member () == "Notify") {
                 try {
                     awaiting_reply = message.copy ();

--- a/src/Services/Session.vala
+++ b/src/Services/Session.vala
@@ -89,7 +89,7 @@ public class Notifications.Session : GLib.Object {
         return list;
     }
 
-    public void add_notification (Notification notification) {
+    public void add_notification (Notification notification, bool write_file = true) {
         string id = notification.id.to_string ();
         key.set_int64 (id, UNIX_TIME_KEY, notification.timestamp.to_unix ());
         key.set_string (id, APP_ICON_KEY, notification.app_icon);
@@ -103,10 +103,12 @@ public class Notifications.Session : GLib.Object {
         key.set_uint64 (id, REPLACES_ID_KEY, notification.replaces_id);
         key.set_boolean (id, HAS_TEMP_FILE_KEY, notification.has_temp_file);
 
-        write_contents ();
+        if (write_file) {
+            write_contents ();
+        }
     }
 
-    public void remove_notification (Notification notification) {
+    public void remove_notification (Notification notification, bool write_file = true) {
         try {
             if (notification.has_temp_file) {
                 var file = File.new_for_path (notification.image_path);
@@ -121,12 +123,14 @@ public class Notifications.Session : GLib.Object {
             warning (e.message);
         }
 
-        write_contents ();
+        if (write_file) {
+            write_contents ();
+        }
     }
 
     public void remove_notifications (Notification[] notifications) {
         foreach (unowned var notification in notifications) {
-            remove_notification (notification);
+            remove_notification (notification, false); // Only update file once
         }
 
         write_contents ();

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -64,6 +64,7 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
 
         clear_btn_entry.clicked.connect (() => {
             clear_all_notification_entries ();
+            clear (); // Causes app entry to be cleared from NotificationList
         });
     }
 
@@ -82,7 +83,7 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
         }
     }
 
-    public void clear_all_notification_entries () {
+    private void clear_all_notification_entries () {
         Notification[] to_remove = {};
         app_notifications.@foreach ((entry) => {
             entry.dismiss ();
@@ -91,6 +92,5 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
 
         app_notifications = new List<NotificationEntry> ();
         Session.get_instance ().remove_notifications (to_remove);
-        clear ();
     }
 }

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -46,7 +46,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
         row_activated.connect (on_row_activated);
     }
 
-    public void add_entry (Notification notification) {
+    public void add_entry (Notification notification, bool write_file = true) {
         var entry = new NotificationEntry (notification);
 
         if (app_entries[notification.desktop_id] != null) {
@@ -71,7 +71,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
         show_all ();
 
-        Session.get_instance ().add_notification (notification);
+        Session.get_instance ().add_notification (notification, write_file);
     }
 
     public void clear_all () {
@@ -97,12 +97,9 @@ public class Notifications.NotificationsList : Gtk.ListBox {
     }
 
     private void clear_app_entry (AppEntry app_entry) {
+        // app_entry must already be cleared of notifications entries
         app_entry.clear.disconnect (clear_app_entry);
-
         app_entries.unset (app_entry.app_id);
-
-        app_entry.clear_all_notification_entries ();
-
         app_entry.destroy ();
 
         if (app_entries.size == 0) {


### PR DESCRIPTION
When clearing all notifications do not rewrite the session file for each notification closed.

This reduces the time take to clear an app's notifications from minutes to seconds when there are >1000 notifications.

Also reduces the complexity of code to clear an app's notifications.

Also incorporates some of #241 for convenience when testing - allows notifications to be added more quickly.