### PR TITLE
Remove notification from list if bubble dismissed; give accurate tooltip count

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -65,15 +65,8 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             dynamic_icon_style_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
             var monitor = NotificationMonitor.get_instance ();
-            Idle.add (() => { // Monitor initialises asynchronously so cannot connect immediately
-                if (monitor.initialized) {
-                    monitor.notification_received.connect (on_notification_received);
-                    monitor.notification_closed.connect (on_notification_closed);
-                    return Source.REMOVE;
-                } else {
-                    return Source.CONTINUE;
-                }
-            });
+            monitor.notification_received.connect (on_notification_received);
+            monitor.notification_closed.connect (on_notification_closed);
 
             dynamic_icon.button_press_event.connect ((e) => {
                 if (e.button == Gdk.BUTTON_MIDDLE) {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -230,8 +230,8 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     }
 
     private void update_tooltip () {
-        uint number_of_notifications = Session.get_instance ().count_notifications ();
-        int number_of_apps = nlist.app_entries.size;
+        uint number_of_apps = 0;
+        uint number_of_notifications = nlist.count_notifications (out number_of_apps);
         string description;
         string accel_label;
 
@@ -255,7 +255,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
                 /// e.g. "2 notifications from 1 app" or "5 notifications from 3 apps"
                 description = _("%s from %s").printf (
                     dngettext (GETTEXT_PACKAGE, "%u notification", "%u notifications", number_of_notifications).printf (number_of_notifications),
-                    dngettext (GETTEXT_PACKAGE, "%i app", "%i apps", number_of_apps).printf (number_of_apps)
+                    dngettext (GETTEXT_PACKAGE, "%u app", "%u apps", number_of_apps).printf (number_of_apps)
                 );
                 break;
         }

--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -16,6 +16,13 @@
  */
 
 public class Notifications.Notification : Object {
+    public enum CloseReason { // Matches enum in io.elementary.notifications
+        EXPIRED = 1,
+        DISMISSED = 2,
+        CLOSE_NOTIFICATION_CALL = 3,
+        UNDEFINED = 4
+    }
+
     public const string DESKTOP_ID_EXT = ".desktop";
 
     public bool is_transient = false;
@@ -34,8 +41,6 @@ public class Notifications.Notification : Object {
 
     public string desktop_id;
     public DesktopAppInfo? app_info = null;
-
-    public signal void closed ();
 
     private enum Column {
         APP_NAME = 0,
@@ -137,10 +142,6 @@ public class Notifications.Notification : Object {
 
         var transient_hint = hints.lookup_value ("transient", VariantType.BOOLEAN);
         is_transient = hints.lookup_value (X_CANONICAL_PRIVATE_KEY, null) != null || (transient_hint != null && transient_hint.get_boolean ());
-    }
-
-    public void close () {
-        closed ();
     }
 
     public bool run_default_action () {

--- a/src/Services/NotificationsMonitor.vala
+++ b/src/Services/NotificationsMonitor.vala
@@ -26,15 +26,17 @@ public class Notifications.NotificationMonitor : Object {
     private const string METHOD_CALL_MATCH_STRING = "type='method_call',interface='org.freedesktop.Notifications'";
     private const string METHOD_RETURN_MATCH_STRING = "type='method_return'";
     private const string ERROR_MATCH_STRING = "type='error'";
-    private const uint32 REASON_DISMISSED = 2;
+    private const string SIGNAL_MATCH_STRING = "type='signal'";
 
     private static NotificationMonitor? instance = null;
 
     private DBusConnection connection;
     private DBusMessage? awaiting_reply = null;
 
+    public bool initialized { get; set; default = false; }
+
     public signal void notification_received (DBusMessage message, uint32 id);
-    public signal void notification_closed (uint32 id);
+    public signal void notification_closed (uint32 id, uint32 reason);
 
     public static NotificationMonitor get_instance () {
         if (instance == null) {
@@ -51,6 +53,8 @@ public class Notifications.NotificationMonitor : Object {
     }
 
     private async void initialize () {
+        initialized = false;
+
         try {
 #if VALA_0_54
             string address = BusType.SESSION.get_address_sync ();
@@ -73,7 +77,8 @@ public class Notifications.NotificationMonitor : Object {
                     new Variant.array (VariantType.STRING, {
                         METHOD_CALL_MATCH_STRING,
                         METHOD_RETURN_MATCH_STRING,
-                        ERROR_MATCH_STRING
+                        ERROR_MATCH_STRING,
+                        SIGNAL_MATCH_STRING
                     }),
                     (uint32)0
                 }),
@@ -91,61 +96,104 @@ public class Notifications.NotificationMonitor : Object {
         } catch (Error e) {
             warning ("Unable to connection to notifications bus: %s", e.message);
         }
+
+        initialized = true;
     }
 
     private DBusMessage? message_filter (DBusConnection con, owned DBusMessage message, bool incoming) {
-        if (incoming && message.get_interface () == NOTIFY_IFACE && message.get_message_type () == DBusMessageType.METHOD_CALL) {
-            if (message.get_member () == "Notify") {
-                try {
-                    awaiting_reply = message.copy ();
-                } catch (Error e) {
-                    warning (e.message);
-                }
-            } else if (message.get_member () == "CloseNotification") {
-                unowned GLib.Variant? body = message.get_body ();
-                if (body == null || body.n_children () != 1) {
-                    return message;
-                }
+        if (incoming && message.get_interface () == NOTIFY_IFACE) {
+            switch (message.get_message_type ()) {
+                case DBusMessageType.METHOD_CALL:
+                    if (message.get_member () == "Notify") {
+                        try {
+                            awaiting_reply = message.copy ();
+                        } catch (Error e) {
+                            warning (e.message);
+                        }
+                    } else if (message.get_member () == "CloseNotification") {
+                        unowned GLib.Variant? body = message.get_body ();
+                        if (body == null || body.n_children () != 1) {
+                            return message;
+                        }
 
-                var child = body.get_child_value (0);
-                if (!child.is_of_type (VariantType.UINT32)) {
-                    return message;
-                }
+                        var child = body.get_child_value (0);
+                        if (!child.is_of_type (VariantType.UINT32)) {
+                            return message;
+                        }
 
-                uint32 id = child.get_uint32 ();
-                Idle.add (() => {
-                    notification_closed (id);
-                    return false;
-                });
+                        uint32 id = child.get_uint32 ();
+                        Idle.add (() => {
+                            notification_closed (id, Notification.CloseReason.CLOSE_NOTIFICATION_CALL);
+                            return Source.REMOVE;
+                        });
+                    }
+
+                    break;
+
+                case DBusMessageType.SIGNAL:
+                    if (message.get_member () == "NotificationClosed") {
+                        unowned GLib.Variant? body = message.get_body ();
+                        if (body == null || body.n_children () != 2) {
+                            return message;
+                        }
+
+                        var id_val = body.get_child_value (0);
+                        if (!id_val.is_of_type (VariantType.UINT32)) {
+                            return message;
+                        }
+
+                        var reason_val = body.get_child_value (1);
+                        if (!reason_val.is_of_type (VariantType.UINT32)) {
+                            return message;
+                        }
+
+                        uint32 id = id_val.get_uint32 ();
+                        uint32 reason = reason_val.get_uint32 ().clamp (1, 4);
+                        Idle.add (() => {
+                            notification_closed (id, reason);
+                            return Source.REMOVE;
+                        });
+                    }
+
+                    break;
+
+                default:
+                    break;
             }
 
             return null;
         } else if (awaiting_reply != null && awaiting_reply.get_serial () == message.get_reply_serial ()) {
-            if (message.get_message_type () == DBusMessageType.METHOD_RETURN) {
-                unowned GLib.Variant? body = message.get_body ();
-                if (body == null || body.n_children () != 1) {
-                    return message;
-                }
+            switch (message.get_message_type ()) {
+                case DBusMessageType.METHOD_RETURN:
+                    unowned GLib.Variant? body = message.get_body ();
+                    if (body == null || body.n_children () != 1) {
+                        return message;
+                    }
 
-                var child = body.get_child_value (0);
-                if (!child.is_of_type (VariantType.UINT32)) {
-                    return message;
-                }
+                    var child = body.get_child_value (0);
+                    if (!child.is_of_type (VariantType.UINT32)) {
+                        return message;
+                    }
 
-                uint32 id = child.get_uint32 ();
-                try {
-                    var copy = awaiting_reply.copy ();
-                    Idle.add (() => {
-                        notification_received (copy, id);
-                        return false;
-                    });
-                } catch (Error e) {
-                    warning (e.message);
-                }
+                    uint32 id = child.get_uint32 ();
+                    try {
+                        var copy = awaiting_reply.copy ();
+                        Idle.add (() => {
+                            notification_received (copy, id);
+                            return Source.REMOVE;
+                        });
+                    } catch (Error e) {
+                        warning (e.message);
+                    }
 
-                awaiting_reply = null;
-            } else if (message.get_message_type () == DBusMessageType.ERROR) {
-                awaiting_reply = null;
+                    awaiting_reply = null;
+                    break;
+
+                case DBusMessageType.ERROR:
+                    awaiting_reply = null;
+                    break;
+                default:
+                    break;
             }
         }
 

--- a/src/Services/NotificationsMonitor.vala
+++ b/src/Services/NotificationsMonitor.vala
@@ -33,8 +33,6 @@ public class Notifications.NotificationMonitor : Object {
     private DBusConnection connection;
     private DBusMessage? awaiting_reply = null;
 
-    public bool initialized { get; set; default = false; }
-
     public signal void notification_received (DBusMessage message, uint32 id);
     public signal void notification_closed (uint32 id, uint32 reason);
 
@@ -53,8 +51,6 @@ public class Notifications.NotificationMonitor : Object {
     }
 
     private async void initialize () {
-        initialized = false;
-
         try {
 #if VALA_0_54
             string address = BusType.SESSION.get_address_sync ();
@@ -96,8 +92,6 @@ public class Notifications.NotificationMonitor : Object {
         } catch (Error e) {
             warning ("Unable to connection to notifications bus: %s", e.message);
         }
-
-        initialized = true;
     }
 
     private DBusMessage? message_filter (DBusConnection con, owned DBusMessage message, bool incoming) {

--- a/src/Services/Session.vala
+++ b/src/Services/Session.vala
@@ -90,15 +90,6 @@ public class Notifications.Session : GLib.Object {
         return list;
     }
 
-    public uint count_notifications () {
-        uint count = 0;
-        foreach (unowned string group in key.get_groups ()) {
-            count++;
-        }
-
-        return count;
-    }
-
     public void add_notification (Notification notification, bool write_file = true) {
         string id = notification.id.to_string ();
         key.set_int64 (id, UNIX_TIME_KEY, notification.timestamp.to_unix ());

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -250,8 +250,6 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
             return GLib.Source.CONTINUE;
         });
 
-        notification.closed.connect (() => clear ());
-
         deck.notify["visible-child"].connect (() => {
             if (deck.transition_running == false && deck.visible_child != overlay) {
                 clear ();

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -79,6 +79,21 @@ public class Notifications.NotificationsList : Gtk.ListBox {
         }
     }
 
+    public uint count_notifications (out uint number_of_apps) {
+        var count = 0;
+        var n_apps = 0;
+        @foreach ((widget) => {
+            if (widget is NotificationEntry) {
+                count++;
+            } else if (widget is AppEntry) {
+                n_apps++;
+            }
+        });
+
+        number_of_apps = n_apps;
+        return count;
+    }
+
     public void clear_all () {
         var iter = app_entries.map_iterator ();
         while (iter.next ()) {


### PR DESCRIPTION
At present if a notification bubble is actively dismissed it remains in the wingpanel list and has to be dismissed again to get rid of it. This seems unexpected.  This PR removes notifications from the list if they are actively closed by the user or a  "CloseNotification" method call. 

It is open to question whether this should also happen in reverse i.e. urgent bubbles should disappear if cleared from the wingpanel list (at present they do not) but that is left for another PR (after hiding bubbles when the indicator is open is implemented).

There was existing code in the NotificationsMonitor that appeared to be intended to implement this already but it did not detect NotificationClosed signals.

A superfluous function/signal was removed from Notification; the Indicator detects when a notification is closed.