### PR TITLE
Constant indicator width

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -129,7 +129,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
 
             main_box = new Gtk.Grid ();
             main_box.orientation = Gtk.Orientation.VERTICAL;
-            main_box.width_request = 300;
+            main_box.width_request = 360;
             main_box.add (not_disturb_switch);
             main_box.add (dnd_switch_separator);
             main_box.add (scrolled);

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -40,7 +40,6 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
         activate_on_single_click = true;
         selection_mode = Gtk.SelectionMode.NONE;
-        width_request = 360;
         set_placeholder (placeholder);
         show_all ();
 

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -40,6 +40,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
         activate_on_single_click = true;
         selection_mode = Gtk.SelectionMode.NONE;
+        width_request = 360;
         set_placeholder (placeholder);
         show_all ();
 


### PR DESCRIPTION
- Set `width_request` of `NotificationsList` to 360 (standard size of a notification)
- Prevent the indicator from resizing when all notifications are cleared

Before:
![Before (trimmed)](https://github.com/elementary/wingpanel-indicator-notifications/assets/106322251/24dfa647-e953-4b53-9bde-236f9d420b22)

After:
![After (trimmed)](https://github.com/elementary/wingpanel-indicator-notifications/assets/106322251/10a34ffa-02b5-420a-918c-5d53dcab4697)
