### PR TITLE
Support Buttons 2

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -163,6 +163,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
     }
 
     private void on_notification_received (DBusMessage message, uint32 id) {
+        print ("notification received");
         var notification = new Notification.from_message (message, id);
         if (notification.is_transient || notification.app_name in EXCEPTIONS) {
             return;

--- a/src/Services/Interfaces.vala
+++ b/src/Services/Interfaces.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-[DBus (name = "org.freedesktop.Notifications")]
+[DBus (name = "io.elementary.Notifications")]
 public interface Notifications.INotifications : Object {
-    public signal void action_invoked (uint32 id, string action);
+    public abstract void invoke_action (uint32 id, string action) throws DBusError, IOError;
 }

--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -156,9 +156,10 @@ public class Notifications.Notification : Object {
                         notifications_iface.invoke_action (id, DEFAULT_ACTION);
                         return true;
                     } catch (Error e) {
-                        warning ("Failed to invoke action '%s': %s", action, e.message);
+                        warning ("Failed to invoke action '%s': %s", DEFAULT_ACTION, e.message);
                     }
                 }
+
             } else if (actions.length == 0) {
                 try {
                     app_info.launch (null, null);

--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -23,6 +23,7 @@ public class Notifications.Notification : Object {
         UNDEFINED = 4
     }
 
+    public const string ACTION_ID = "fdo-%u.%s";
     public const string DESKTOP_ID_EXT = ".desktop";
     public const string DEFAULT_ACTION = "default";
 
@@ -145,19 +146,15 @@ public class Notifications.Notification : Object {
     }
 
     public bool action_invoked (string action) {
-        var notifications_iface = NotificationMonitor.get_instance ().notifications_iface;
+        var notification_actions = NotificationMonitor.get_instance ().notification_actions;
 
         if (action == DEFAULT_ACTION) {
             if (DEFAULT_ACTION in actions) {
                 app_info.launch_action (DEFAULT_ACTION, new GLib.AppLaunchContext ());
 
-                if (notifications_iface != null) {
-                    try {
-                        notifications_iface.invoke_action (id, DEFAULT_ACTION);
-                        return true;
-                    } catch (Error e) {
-                        warning ("Failed to invoke action '%s': %s", DEFAULT_ACTION, e.message);
-                    }
+                if (notification_actions != null) {
+                    notification_actions.activate_action ("fdo-" + id.to_string () + "." + DEFAULT_ACTION, null);
+                    return true;
                 }
 
             } else if (actions.length == 0) {
@@ -171,9 +168,9 @@ public class Notifications.Notification : Object {
 
             return false;
         } else {
-            if (notifications_iface != null) {
+            if (notification_actions != null) {
                 try {
-                    notifications_iface.invoke_action (id, action);
+                    notification_actions.activate_action ("fdo-" + id.to_string () + "." + action, null);
                     return true;
                 } catch (Error e) {
                     warning ("Failed to invoke action '%s': %s", action, e.message);

--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -152,10 +152,13 @@ public class Notifications.Notification : Object {
                 app_info.launch_action (DEFAULT_ACTION, new GLib.AppLaunchContext ());
 
                 if (notifications_iface != null) {
-                    notifications_iface.action_invoked (id, DEFAULT_ACTION);
+                    try {
+                        notifications_iface.invoke_action (id, DEFAULT_ACTION);
+                        return true;
+                    } catch (Error e) {
+                        warning ("Failed to invoke action '%s': %s", action, e.message);
+                    }
                 }
-
-                return true;
             } else if (actions.length == 0) {
                 try {
                     app_info.launch (null, null);
@@ -168,8 +171,12 @@ public class Notifications.Notification : Object {
             return false;
         } else {
             if (notifications_iface != null) {
-                notifications_iface.action_invoked (id, DEFAULT_ACTION);
-                return true;
+                try {
+                    notifications_iface.invoke_action (id, action);
+                    return true;
+                } catch (Error e) {
+                    warning ("Failed to invoke action '%s': %s", action, e.message);
+                }
             }
 
             return false;

--- a/src/Services/NotificationsMonitor.vala
+++ b/src/Services/NotificationsMonitor.vala
@@ -44,7 +44,7 @@ public class Notifications.NotificationMonitor : Object {
         return instance;
     }
 
-    public INotifications? notifications_iface = null;
+    public DBusActionGroup? notification_actions = null;
 
     construct {
         initialize.begin ();
@@ -87,11 +87,8 @@ public class Notifications.NotificationMonitor : Object {
             critical ("Unable to monitor notifications bus: %s", e.message);
         }
 
-        try {
-            notifications_iface = yield Bus.get_proxy (BusType.SESSION, NOTIFY_IFACE, NOTIFY_PATH, DBusProxyFlags.NONE, null);
-        } catch (Error e) {
-            warning ("Unable to connection to notifications bus: %s", e.message);
-        }
+        notification_actions = DBusActionGroup.get (connection, "io.elementary.notifications", "/org/freedesktop/Notifications");
+        print ("initialized");
     }
 
     private DBusMessage? message_filter (DBusConnection con, owned DBusMessage message, bool incoming) {

--- a/src/Services/NotificationsMonitor.vala
+++ b/src/Services/NotificationsMonitor.vala
@@ -21,8 +21,8 @@
  */
 
 public class Notifications.NotificationMonitor : Object {
-    private const string NOTIFY_IFACE = "org.freedesktop.Notifications";
-    private const string NOTIFY_PATH = "/org/freedesktop/Notifications";
+    private const string NOTIFY_IFACE = "io.elementary.notifications";
+    private const string NOTIFY_PATH = "/io/elementary/notifications";
     private const string METHOD_CALL_MATCH_STRING = "type='method_call',interface='org.freedesktop.Notifications'";
     private const string METHOD_RETURN_MATCH_STRING = "type='method_return'";
     private const string ERROR_MATCH_STRING = "type='error'";

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -47,6 +47,8 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
     }
 
     construct {
+        insert_action_group ("fdo-" + notification.id.to_string (), NotificationMonitor.get_instance ().notification_actions);
+
         var app_image = new Gtk.Image ();
 
         if (notification.app_icon.contains ("/")) {
@@ -138,7 +140,9 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         var delete_button = new Gtk.Button () {
             halign = Gtk.Align.START,
             valign = Gtk.Align.START,
-            image = delete_image
+            image = delete_image,
+            action_name = "close",
+            action_target = notification.id
         };
         delete_button.get_style_context ().add_class ("close");
         delete_button.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
@@ -203,14 +207,13 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
                     continue;
                 }
 
-                var button = new Gtk.Button.with_label (notification.actions[i + 1]);
-                var action = notification.actions[i].dup ();
+                var button = new Gtk.Button.with_label (notification.actions[i + 1]) {
+                    action_name = Notification.ACTION_ID.printf (notification.id, notification.actions[i])
+                };
 
                 button.clicked.connect (() => {
-                    if (notification.action_invoked (action)) {
-                        activate ();
-                        clear ();
-                    }
+                    activate ();
+                    clear ();
                 });
 
                 action_area.pack_end (button);
@@ -268,10 +271,12 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         show_all ();
 
         button_release_event.connect (() => {
-            if (notification.action_invoked (Notification.DEFAULT_ACTION)) {
+            // unowned var action_group = get_action_group ("fdo-" + notification.id.to_string ());
+            // action_gr
+            // if (notification.action_invoked (Notification.DEFAULT_ACTION)) {
                 activate ();
                 clear ();
-            }
+            // }
 
             return Gdk.EVENT_STOP;
         });

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -38,7 +38,6 @@ public class Notifications.NotificationsList : Gtk.ListBox {
         placeholder_style_context.add_class (Granite.STYLE_CLASS_H2_LABEL);
         placeholder_style_context.add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
-        activate_on_single_click = true;
         selection_mode = Gtk.SelectionMode.NONE;
         set_placeholder (placeholder);
         show_all ();
@@ -114,10 +113,6 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
     private void on_row_activated (Gtk.ListBoxRow row) {
         if (row is NotificationEntry) {
-            unowned NotificationEntry notification_entry = (NotificationEntry) row;
-            notification_entry.notification.run_default_action ();
-            notification_entry.clear ();
-
             close_popover ();
         }
     }


### PR DESCRIPTION
- Support buttons

~Currently doesn't work~ because it seems emitting signals on a foreign DBus Object (is this correct terminology?)  isn't possible (which would make sense). However it was used here before (for the default action) so maybe I missed something?
A possible solution would maybe be to implement a DBus method in elementary/notifications that then emits the `ActionInvoked` signal on `org.freedesktop.Notifications`.