### PR TITLE
Allow turning off keeping notifications accross reboots

### DIFF
--- a/data/io.elementary.wingpanel.notifications.gschema.xml
+++ b/data/io.elementary.wingpanel.notifications.gschema.xml
@@ -9,7 +9,7 @@
   <key name="keep-notifications" type="b">
     <default>true</default>
     <summary>Keep notifications</summary>
-    <description>Whether to keep notifications accross reboots</description>
+    <description>Keep new notifications between sessions</description>
   </key>
 </schema>
 </schemalist>

--- a/data/io.elementary.wingpanel.notifications.gschema.xml
+++ b/data/io.elementary.wingpanel.notifications.gschema.xml
@@ -6,5 +6,10 @@
     <summary>The expanded state of the headers</summary>
     <description>The expanded state of the headers</description>
   </key>
+  <key name="keep-notifications" type="b">
+    <default>true</default>
+    <summary>Keep notifications</summary>
+    <description>Whether to keep notifications accross reboots</description>
+  </key>
 </schema>
 </schemalist>

--- a/data/io.elementary.wingpanel.notifications.gschema.xml
+++ b/data/io.elementary.wingpanel.notifications.gschema.xml
@@ -9,7 +9,7 @@
   <key name="keep-notifications" type="b">
     <default>true</default>
     <summary>Keep notifications</summary>
-    <description>Keep new notifications between sessions</description>
+    <description>Whether to keep new notifications between sessions</description>
   </key>
 </schema>
 </schemalist>

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -80,7 +80,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
         yield;
 
         if (add_to_session) { // If notification was obtained from session do not write it back
-            Session.get_instance ().add_notification (notification);
+            Session.get_instance ().add_notification (notification,Notifications.Session.notify_settings);
         }
     }
 

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -25,7 +25,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
     private HashTable<string, int> table;
 
-    private static GLib.Settings? settings;
+    private GLib.Settings notify_settings;
 
     construct {
         app_entries = new Gee.HashMap<string, AppEntry> ();
@@ -83,7 +83,8 @@ public class Notifications.NotificationsList : Gtk.ListBox {
         yield;
 
         if (add_to_session) { // If notification was obtained from session do not write it back
-            Session.get_instance ().add_notification (notification,notify_settings.Get_Boolean("keep-notifications"));
+            var write_file = notify_settings.get_boolean ( "keep-notifications");
+            Session.get_instance ().add_notification (notification, write_file);
         }
     }
 

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -25,9 +25,12 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
     private HashTable<string, int> table;
 
+    private static GLib.Settings? settings;
+
     construct {
         app_entries = new Gee.HashMap<string, AppEntry> ();
         table = new HashTable<string, int> (str_hash, str_equal);
+        notify_settings = new GLib.Settings ("io.elementary.notifications");
 
         var placeholder = new Gtk.Label (_("No Notifications")) {
             margin_top = 24,
@@ -80,7 +83,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
         yield;
 
         if (add_to_session) { // If notification was obtained from session do not write it back
-            Session.get_instance ().add_notification (notification,Notifications.Session.notify_settings);
+            Session.get_instance ().add_notification (notification,notify_settings.Get_Boolean("keep-notifications"));
         }
     }
 

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -30,7 +30,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
     construct {
         app_entries = new Gee.HashMap<string, AppEntry> ();
         table = new HashTable<string, int> (str_hash, str_equal);
-        notify_settings = new GLib.Settings ("io.elementary.notifications");
+        notify_settings = new GLib.Settings ("io.elementary.wingpanel.notifications");
 
         var placeholder = new Gtk.Label (_("No Notifications")) {
             margin_top = 24,
@@ -56,6 +56,7 @@ public class Notifications.NotificationsList : Gtk.ListBox {
 
     public async void add_entry (Notification notification, bool add_to_session = true) {
         var entry = new NotificationEntry (notification);
+        var write_file = notify_settings.get_boolean ( "keep-notifications");
 
         if (app_entries[notification.desktop_id] != null) {
             var app_entry = app_entries[notification.desktop_id];
@@ -83,7 +84,6 @@ public class Notifications.NotificationsList : Gtk.ListBox {
         yield;
 
         if (add_to_session) { // If notification was obtained from session do not write it back
-            var write_file = notify_settings.get_boolean ( "keep-notifications");
             Session.get_instance ().add_notification (notification, write_file);
         }
     }


### PR DESCRIPTION

this allows disabling the Session feature for those who do not want it
There is no toggle in the UI - It isnt a proposed change to desktop experience, only a tweak.

this could be an answer for those who perceive notification persistence as a bug/undesirable: https://github.com/elementary/wingpanel-indicator-notifications/issues/277

or ignore that part of the desktop until it becomes a problem:
https://github.com/elementary/wingpanel-indicator-notifications/issues/237

only new notifications do not get saved, when you toggle this to false. The already saved ones are kept.