### PR TITLE
NotificationEntry: GTK4 prep

### DIFF
--- a/data/NotificationEntry.css
+++ b/data/NotificationEntry.css
@@ -1,4 +1,4 @@
-.card {
+notification .card {
     border-radius: 6px;
     padding: 6px;
 }
@@ -24,7 +24,7 @@
     font-weight: 600;
 }
 
-.close {
+notification .close {
     padding: 3px;
     border: none;
     border-radius: 100%;
@@ -44,7 +44,7 @@
     margin: 3px;
 }
 
-.close image {
+notification .close image {
     color: #fff;
     -gtk-icon-shadow: 0 1px 1px alpha (#000, 0.6);
 }

--- a/data/NotificationEntry.css
+++ b/data/NotificationEntry.css
@@ -1,6 +1,12 @@
 notification .card {
     border-radius: 6px;
     padding: 6px;
+    /* Box shadow is clipped to the margin area */
+    margin: 0.75em 1em;
+}
+
+notification .title {
+    font-weight: bold;
 }
 
 .delete-affordance {

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -48,8 +48,9 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
             app_image.icon_name = notification.app_icon;
         }
 
-        var image_overlay = new Gtk.Overlay ();
-        image_overlay.valign = Gtk.Align.START;
+        var image_overlay = new Gtk.Overlay () {
+            valign = START
+        };
 
         if (notification.image_path != null && notification.image_path != "") {
             try {
@@ -59,24 +60,24 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
                 var masked_image = new Notifications.MaskedImage (pixbuf);
 
                 app_image.pixel_size = ICON_SIZE_SECONDARY;
-                app_image.halign = app_image.valign = Gtk.Align.END;
+                app_image.halign = app_image.valign = END;
 
-                image_overlay.add (masked_image);
+                image_overlay.child = masked_image;
                 image_overlay.add_overlay (app_image);
             } catch (Error e) {
                 critical ("Unable to mask image: %s", e.message);
 
                 app_image.pixel_size = ICON_SIZE_PRIMARY;
-                image_overlay.add (app_image);
+                image_overlay.child = app_image;
             }
         } else {
             app_image.pixel_size = ICON_SIZE_PRIMARY;
-            image_overlay.add (app_image);
+            image_overlay.child = app_image;
 
             if (notification.badge_icon != null) {
                 var badge_image = new Gtk.Image.from_gicon (notification.badge_icon, Gtk.IconSize.LARGE_TOOLBAR) {
-                    halign = Gtk.Align.END,
-                    valign = Gtk.Align.END,
+                    halign = END,
+                    valign = END,
                     pixel_size = ICON_SIZE_SECONDARY
                 };
                 image_overlay.add_overlay (badge_image);
@@ -94,7 +95,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         }
 
         var title_label = new Gtk.Label ("<b>%s</b>".printf (fix_markup (entry_title))) {
-            ellipsize = Pango.EllipsizeMode.END,
+            ellipsize = END,
             hexpand = true,
             width_chars = 27,
             max_width_chars = 27,
@@ -124,21 +125,21 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         delete_image.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var delete_button = new Gtk.Button () {
-            halign = Gtk.Align.START,
-            valign = Gtk.Align.START,
+            halign = START,
+            valign = START,
             image = delete_image
         };
         delete_button.get_style_context ().add_class ("close");
         delete_button.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var delete_revealer = new Gtk.Revealer () {
-            halign = Gtk.Align.START,
-            valign = Gtk.Align.START,
+            child = delete_button,
+            halign = START,
+            valign = START,
             reveal_child = false,
             transition_duration = Granite.TRANSITION_DURATION_CLOSE,
-            transition_type = Gtk.RevealerTransitionType.CROSSFADE
+            transition_type = CROSSFADE
         };
-        delete_revealer.add (delete_button);
 
         grid.attach (image_overlay, 0, 0, 1, 2);
         grid.attach (title_label, 1, 0);
@@ -153,11 +154,11 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         var body = fix_markup (entry_body);
 
         var body_label = new Gtk.Label (body) {
-            ellipsize = Pango.EllipsizeMode.END,
+            ellipsize = END,
             lines = 2,
             use_markup = true,
-            valign = Gtk.Align.START,
-            wrap_mode = Pango.WrapMode.WORD_CHAR,
+            valign = START,
+            wrap_mode = WORD_CHAR,
             wrap = true,
             xalign = 0
         };
@@ -177,9 +178,9 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         grid.attach (body_label, 1, 1, 2);
 
         if (notification.buttons.length () > 0) {
-            var action_area = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
+            var action_area = new Gtk.Box (HORIZONTAL, 6) {
                 margin_top = 12,
-                halign = Gtk.Align.END,
+                halign = END,
                 homogeneous = true
             };
             grid.attach (action_area, 0, 2, 3);
@@ -189,22 +190,23 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
             };
         }
 
-        var delete_left = new DeleteAffordance (Gtk.Align.END) {
+        var delete_left = new DeleteAffordance (END) {
             // Have to match with the grid
             margin_top = 9,
             margin_bottom = 9
         };
         delete_left.get_style_context ().add_class ("left");
 
-        var delete_right = new DeleteAffordance (Gtk.Align.START) {
+        var delete_right = new DeleteAffordance (START) {
             // Have to match with the grid
             margin_top = 9,
             margin_bottom = 9
         };
         delete_right.get_style_context ().add_class ("right");
 
-        var overlay = new Gtk.Overlay ();
-        overlay.add (grid);
+        var overlay = new Gtk.Overlay () {
+            child = grid
+        };
         overlay.add_overlay (delete_revealer);
 
         var deck = new Hdy.Deck () {
@@ -218,11 +220,11 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         deck.visible_child = overlay;
 
         revealer = new Gtk.Revealer () {
+            child = deck,
             reveal_child = true,
             transition_duration = 200,
-            transition_type = Gtk.RevealerTransitionType.SLIDE_UP
+            transition_type = SLIDE_UP
         };
-        revealer.add (deck);
 
         var eventbox = new Gtk.EventBox ();
         eventbox.events |= Gdk.EventMask.ENTER_NOTIFY_MASK &
@@ -230,7 +232,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         eventbox.add (revealer);
 
-        add (eventbox);
+        child = eventbox;
 
         show_all ();
 
@@ -304,7 +306,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
                 halign = alignment,
                 hexpand = true,
                 row_spacing = 3,
-                valign = Gtk.Align.CENTER,
+                valign = CENTER,
                 vexpand = true
             };
             delete_internal_grid.attach (image, 0, 0);

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -14,7 +14,6 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
     private const int ICON_SIZE_PRIMARY = 48;
     private const int ICON_SIZE_SECONDARY = 24;
 
-    private static Gtk.CssProvider provider;
     private static Regex entity_regex;
     private static Regex tag_regex;
 
@@ -23,15 +22,25 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
     }
 
     static construct {
-        provider = new Gtk.CssProvider ();
-        provider.load_from_resource ("io/elementary/wingpanel/notifications/NotificationEntry.css");
-
         try {
             entity_regex = new Regex ("&(?!amp;|quot;|apos;|lt;|gt;|nbsp;|#39)");
             tag_regex = new Regex ("<(?!\\/?[biu]>)");
         } catch (Error e) {
             warning ("Invalid regex: %s", e.message);
         }
+    }
+
+    class construct {
+        set_css_name ("notification");
+
+        var provider = new Gtk.CssProvider ();
+        provider.load_from_resource ("io/elementary/wingpanel/notifications/NotificationEntry.css");
+
+        Gtk.StyleContext.add_provider_for_screen (
+            Gdk.Screen.get_default (),
+            provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        );
     }
 
     construct {
@@ -119,10 +128,8 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         unowned Gtk.StyleContext grid_context = grid.get_style_context ();
         grid_context.add_class (Granite.STYLE_CLASS_CARD);
-        grid_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var delete_image = new Gtk.Image.from_icon_name ("window-close-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-        delete_image.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var delete_button = new Gtk.Button () {
             halign = START,
@@ -130,7 +137,6 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
             image = delete_image
         };
         delete_button.get_style_context ().add_class ("close");
-        delete_button.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var delete_revealer = new Gtk.Revealer () {
             child = delete_button,
@@ -295,12 +301,10 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         construct {
             var image = new Gtk.Image.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
-            image.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
             var label = new Gtk.Label ("<small>%s</small>".printf (_("Delete"))) {
                 use_markup = true
             };
-            label.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
             var delete_internal_grid = new Gtk.Grid () {
                 halign = alignment,
@@ -316,7 +320,6 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
             unowned Gtk.StyleContext context = get_style_context ();
             context.add_class ("delete-affordance");
-            context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
     }
 

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -1,19 +1,7 @@
-/*-
- * Copyright (c) 2015-2018 elementary LLC. (https://elementary.io)
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Library General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Library General Public License for more details.
- *
- * You should have received a copy of the GNU Library General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+/*
+* SPDX-License-Identifier: LGPL-2.1-or-later
+* SPDX-FileCopyrightText: 2015-2025 elementary, Inc. (https://elementary.io)
+*/
 
 public class Notifications.NotificationEntry : Gtk.ListBoxRow {
     public signal void clear ();

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -124,12 +124,10 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         };
         grid.get_style_context ().add_class (Granite.STYLE_CLASS_CARD);
 
-        var delete_image = new Gtk.Image.from_icon_name ("window-close-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 
-        var delete_button = new Gtk.Button () {
+        var delete_button = new Gtk.Button.from_icon_name ("window-close-symbolic") {
             halign = START,
-            valign = START,
-            image = delete_image
+            valign = START
         };
         delete_button.get_style_context ().add_class ("close");
 

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -285,7 +285,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         }
     }
 
-    private class DeleteAffordance : Gtk.Grid {
+    private class DeleteAffordance : Gtk.Bin {
         public Gtk.Align alignment { get; construct; }
 
         public DeleteAffordance (Gtk.Align alignment) {
@@ -308,10 +308,9 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
             delete_internal_grid.attach (image, 0, 0);
             delete_internal_grid.attach (label, 0, 1);
 
-            add (delete_internal_grid);
+            child = delete_internal_grid;
 
-            unowned Gtk.StyleContext context = get_style_context ();
-            context.add_class ("delete-affordance");
+            get_style_context ().add_class ("delete-affordance");
         }
     }
 

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -103,7 +103,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
             entry_title = notification.app_name;
         }
 
-        var title_label = new Gtk.Label ("<b>%s</b>".printf (fix_markup (entry_title))) {
+        var title_label = new Gtk.Label (fix_markup (entry_title)) {
             ellipsize = END,
             hexpand = true,
             width_chars = 27,
@@ -111,6 +111,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
             use_markup = true,
             xalign = 0
         };
+        title_label.get_style_context ().add_class ("title");
 
         var time_label = new Gtk.Label (Granite.DateTime.get_relative_datetime (notification.timestamp)) {
             margin_end = 6
@@ -119,15 +120,9 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         var grid = new Gtk.Grid () {
             hexpand = true,
-            column_spacing = 6,
-            margin = 12,
-            // Box shadow is clipped to the margin area
-            margin_top = 9,
-            margin_bottom = 9
+            column_spacing = 6
         };
-
-        unowned Gtk.StyleContext grid_context = grid.get_style_context ();
-        grid_context.add_class (Granite.STYLE_CLASS_CARD);
+        grid.get_style_context ().add_class (Granite.STYLE_CLASS_CARD);
 
         var delete_image = new Gtk.Image.from_icon_name ("window-close-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 
@@ -302,9 +297,8 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         construct {
             var image = new Gtk.Image.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
 
-            var label = new Gtk.Label ("<small>%s</small>".printf (_("Delete"))) {
-                use_markup = true
-            };
+            var label = new Gtk.Label (_("Delete"));
+            label.get_style_context ().add_class (Granite.STYLE_CLASS_SMALL_LABEL);
 
             var delete_internal_grid = new Gtk.Grid () {
                 halign = alignment,


### PR DESCRIPTION
Can be rebase merged if desired

* Code style. Use child property for revealers, overlays, etc
* Adding providers to a style context is deprecated
* Prefer CSS to markup where possible
* No "add" in grid