### PR TITLE
NotificationEntry: bind hide to settings

### DIFF
--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -123,8 +123,6 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
     public void add_notification_entry (NotificationEntry entry) {
         app_notifications.prepend (entry);
         entry.clear.connect (remove_notification_entry);
-
-        expander.bind_property ("active", entry.revealer, "reveal-child", SYNC_CREATE);
     }
 
     public void remove_notification_entry (NotificationEntry entry) {

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -244,7 +244,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         settings.bind_with_mapping (
             "headers", revealer, "reveal-child", GET,
-            (SettingsBindGetMappingShared) get_bind_func, () => false,
+            get_bind_func, () => false,
             new Variant.string (notification.desktop_id), null
         );
 

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -14,9 +14,9 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
     private const int ICON_SIZE_PRIMARY = 48;
     private const int ICON_SIZE_SECONDARY = 24;
 
-    private static Settings settings;
     private static Regex entity_regex;
     private static Regex tag_regex;
+    private static Settings settings;
 
     public NotificationEntry (Notification notification) {
         Object (notification: notification);
@@ -247,7 +247,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
             (value, variant, user_data) => {
                 var app_id = ((Variant) user_data).get_string ();
                 var headers_table = (HashTable<string, bool>) variant;
-                value.set_boolean (headers_table[app_id ]);
+                value.set_boolean (headers_table[app_id]);
                 return true;
             },
             () => false,

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -14,6 +14,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
     private const int ICON_SIZE_PRIMARY = 48;
     private const int ICON_SIZE_SECONDARY = 24;
 
+    private static Settings settings;
     private static Regex entity_regex;
     private static Regex tag_regex;
 
@@ -28,6 +29,8 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         } catch (Error e) {
             warning ("Invalid regex: %s", e.message);
         }
+
+        settings = new Settings ("io.elementary.panel.notifications");
     }
 
     class construct {
@@ -238,6 +241,18 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         motion_controller.leave.connect (() => {
             delete_revealer.reveal_child = false;
         });
+
+        settings.bind_with_mapping (
+            "headers", revealer, "reveal-child", GET,
+            (value, variant, user_data) => {
+                var app_id = ((Variant) user_data).get_string ();
+                var headers_table = (HashTable<string, bool>) variant;
+                value.set_boolean (headers_table[app_id ]);
+                return true;
+            },
+            () => false,
+            new Variant.string (notification.desktop_id), null
+        );
 
         revealer.add_controller (motion_controller);
 

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -244,13 +244,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         settings.bind_with_mapping (
             "headers", revealer, "reveal-child", GET,
-            (value, variant, user_data) => {
-                var app_id = ((Variant) user_data).get_string ();
-                var headers_table = (HashTable<string, bool>) variant;
-                value.set_boolean (headers_table[app_id]);
-                return true;
-            },
-            () => false,
+            (SettingsBindGetMappingShared) get_bind_func, () => false,
             new Variant.string (notification.desktop_id), null
         );
 
@@ -266,6 +260,13 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
                 clear ();
             }
         });
+    }
+
+    private static bool get_bind_func (Value value, Variant variant, void* user_data) {
+        var app_id = ((Variant) user_data).get_string ();
+        var headers_table = (HashTable<string, bool>) variant;
+        value.set_boolean (headers_table[app_id]);
+        return true;
     }
 
     public void dismiss () {


### PR DESCRIPTION
Make sure we're using settings as the source of truth and not UI. This is admittedly more complicated seeming but when we are using ListView it will make it easier to recycle list items 