### PR TITLE
NotificationsList: handle clearing app entry

### DIFF
--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -107,7 +107,6 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
 
         clear_btn_entry.clicked.connect (() => {
             clear_btn_image.add_css_class ("active");
-            clear_all_notification_entries ();
             GLib.Timeout.add (600, () => {
                 clear (); // Causes notification list to destroy this app entry after clearing its notification entries
                 return GLib.Source.REMOVE;
@@ -137,16 +136,5 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
 
             clear ();
         }
-    }
-
-    public void clear_all_notification_entries () {
-        Notification[] to_remove = {};
-        app_notifications.@foreach ((entry) => {
-            entry.dismiss ();
-            to_remove += entry.notification;
-        });
-
-        app_notifications = new List<NotificationEntry> ();
-        Session.get_instance ().remove_notifications (to_remove);
     }
 }

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -145,7 +145,24 @@ public class Notifications.NotificationsList : Granite.Bin {
     private void clear_app_entry (AppEntry app_entry) {
         app_entry.clear.disconnect (clear_app_entry);
         app_entries.unset (app_entry.app_id);
-        app_entry.clear_all_notification_entries ();
+        app_entry.app_notifications = new List<NotificationEntry> ();
+
+        var settings = new Settings ("io.elementary.panel.notifications");
+        var headers = (HashTable<string, bool>) settings.get_value ("headers");
+        if (headers.remove (app_entry.app_id)) {
+            settings.set_value ("headers", headers);
+        }
+
+        Notification[] to_remove = {};
+        for (int i = 0; i < list_store.n_items; i++) {
+            var entry = (NotificationEntry) list_store.get_item (i);
+            if (entry.notification.desktop_id == app_entry.app_id) {
+                entry.dismiss ();
+                to_remove += entry.notification;
+            }
+        }
+
+        Session.get_instance ().remove_notifications (to_remove);
 
         if (app_entries.size == 0) {
             Session.get_instance ().clear ();


### PR DESCRIPTION
Another part of trying to make sure headers are as dumb as possible so they can be more easily freed and not hold extra references to notifications

* `AppEntry.clear ()` calls `NotificationsList.clear_app_entry ()` which calls `AppEntry.clear_all_notification_entries ()`, so remove this duplicate call
* Handle clearing notification entries and updating settings in NotificationsList