### PR TITLE
Styles: use OSD style for close button

### DIFF
--- a/data/NotificationEntry.css
+++ b/data/NotificationEntry.css
@@ -32,27 +32,32 @@ delete-affordance label {
     font-weight: 600;
 }
 
-notification .close {
-    padding: 3px;
-    border: none;
-    border-radius: 100%;
-    background-image:
-        linear-gradient(
-            to bottom,
-            @BLACK_300,
-            @BLACK_500
-        );
-    box-shadow:
-        inset 0 0 0 1px alpha(#fff, 0.02),
-        inset 0 1px 0 0 alpha(#fff, 0.07),
-        inset 0 -1px 0 0 alpha(#fff, 0.01),
-        0 0 0 1px alpha(#000, 0.7),
-        0 1px 2px alpha(#000, 0.16),
-        0 2px 3px alpha(#000, 0.23);
-    margin: 3px;
+notification .osd {
+    backdrop-filter: blur(6px);
+    background-color: alpha(@bg_color, 0.2);
+    color: @text_color;
+    margin: 0.25rem;
+    -gtk-icon-shadow: 0 1px 1px alpha(@bg_color, 0.6);
 }
 
-notification .close image {
-    color: #fff;
-    -gtk-icon-shadow: 0 1px 1px alpha(#000, 0.6);
+notification .osd.circular {
+    background-image:
+        linear-gradient(
+            to top,
+                alpha(@highlight_color, 0.3),
+                transparent calc(100% - 0.5rem),
+        ),
+        radial-gradient(
+            ellipse 65% 50%,
+            transparent calc(100% - 0.5rem),
+            alpha(@highlight_color, 0.25)
+        );
+    border-radius: 100%;
+    box-shadow:
+        inset 0 1px 0 0 alpha(@highlight_color, 0.6),
+        inset 1px 0 0 0 alpha(@highlight_color, 0.07),
+        inset -1px 0 0 0 alpha(@highlight_color, 0.07),
+        inset 0 -1px 0 0 alpha(@highlight_color, 0.8),
+        0 2px 4px alpha(black, 0.1),
+        0 1px 2px alpha(black, 0.1);
 }

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -129,12 +129,12 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         };
         grid.add_css_class (Granite.CssClass.CARD);
 
-
         var delete_button = new Gtk.Button.from_icon_name ("window-close-symbolic") {
             halign = START,
             valign = START
         };
-        delete_button.add_css_class ("close");
+        delete_button.add_css_class (Granite.STYLE_CLASS_OSD);
+        delete_button.add_css_class (Granite.CssClass.CIRCULAR);
 
         var delete_revealer = new Gtk.Revealer () {
             child = delete_button,
@@ -225,7 +225,8 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
             child = carousel,
             reveal_child = true,
             transition_duration = 200,
-            transition_type = SLIDE_UP
+            transition_type = SLIDE_UP,
+            overflow = VISIBLE
         };
 
         child = revealer;


### PR DESCRIPTION
fixes #226

Flirting with a glassy osd style
<img width="103" height="119" alt="Screenshot from 2026-08-28 13 20 46" src="https://github.com/user-attachments/assets/5763a943-3c71-44e4-94d1-fa80742ab7a3" />
<img width="100" height="124" alt="Screenshot from 2026-08-28 13 21 06" src="https://github.com/user-attachments/assets/39ff691c-63a6-41fa-8448-ca947fcab8e7" />
